### PR TITLE
Module Interface Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This is written and tested using grpcurl and postman.  It supports both v1alpha 
 1. Create a reflection server
   ```elixir
   defmodule Helloworld.Reflection.Server do
-    use GrpcReflection,
+    use GrpcReflection.Server,
       version: :v1,
       services: [Helloworld.Greeter.Service]
   end
@@ -37,7 +37,7 @@ This is written and tested using grpcurl and postman.  It supports both v1alpha 
   or
   ```elixir
   defmodule Helloworld.Reflection.Server2 do
-    use GrpcReflection,
+    use GrpcReflection.Server,
       version: :v1alpha,
       services: [Helloworld.Greeter.Service]
   end

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ message HelloReply {
 
 ## Protobuf Version Support
 
-This utility currently only supports proto3.  It does not support some of the features of proto2, including extensions.
+This module is more thoroughly tested with proto3, but it has some testing with proto2.  In either case feedback is appreciated as we approach full proto support in this module.
 
 ## Application Support
 
-This is **not** an exhaustive list
+This is **not** an exhaustive list, contributions are appreciated.
 
 | Application  | Reflection version required |
 | ------------- | ------------- |

--- a/examples/helloworld/lib/reflection_server.ex
+++ b/examples/helloworld/lib/reflection_server.ex
@@ -1,5 +1,5 @@
 defmodule Helloworld.Reflection.Server do
-  use GrpcReflection,
+  use GrpcReflection.Server,
     version: :v1,
     services: [Helloworld.Greeter.Service]
 end

--- a/lib/grpc_reflection.ex
+++ b/lib/grpc_reflection.ex
@@ -34,7 +34,6 @@ defmodule GrpcReflection do
   end
   ```
   """
-  use Supervisor
 
   @type descriptor_t ::
           %Google.Protobuf.DescriptorProto{} | %Google.Protobuf.ServiceDescriptorProto{}
@@ -130,35 +129,13 @@ defmodule GrpcReflection do
     end
   end
 
-  def start_link(opts) do
-    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
-  end
-
-  @impl true
-  def init(opts) do
-    children = [
-      %{
-        id: OneOffTask,
-        start: {Task, :start_link, [__MODULE__, :one_off_task, []]},
-        type: :worker,
-        restart: :temporary
-      },
-      %{
-        id: GrpcReflection.DynamicSupervisor,
-        start: {GrpcReflection.DynamicSupervisor, :start_link, [opts]},
-        type: :supervisor,
-        restart: :permanent
-      }
-    ]
-
-    Supervisor.init(children, strategy: :one_for_one)
-  end
-
-  @doc """
-  Load the protobuf extensions
-  """
-  def one_off_task do
-    Protobuf.load_extensions()
-    :ignore
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: GrpcReflection,
+      start: {GrpcReflection.Supervisor, :start_link, [opts]},
+      type: :supervisor,
+      restart: :permanent
+    }
   end
 end

--- a/lib/grpc_reflection.ex
+++ b/lib/grpc_reflection.ex
@@ -9,7 +9,7 @@ defmodule GrpcReflection do
   1. Create your reflection server
   ```elixir
   defmodule Helloworld.Reflection.Server do
-    use GrpcReflection,
+    use GrpcReflection.Server,
       version: :v1,
       services: [Helloworld.Greeter.Service]
   end
@@ -35,97 +35,16 @@ defmodule GrpcReflection do
   ```
   """
 
-  @type descriptor_t ::
-          %Google.Protobuf.DescriptorProto{} | %Google.Protobuf.ServiceDescriptorProto{}
+  require Logger
 
-  # credo:disable-for-next-line
   defmacro __using__(opts) when is_list(opts) do
-    services = Keyword.get(opts, :services, [])
-    version = Keyword.get(opts, :version, :none)
+    Logger.warning("""
+    `use GrpcReflection` is deprecated.
+    Please replace with `use GrpcReflection.Server` instead
+    """)
 
     quote do
-      @cfg {__MODULE__, unquote(services)}
-
-      @doc """
-      Get the current list of configured services
-      """
-      @spec list_services :: list(binary)
-      def list_services do
-        GrpcReflection.Service.Agent.list_services(@cfg)
-      end
-
-      @doc """
-      Get the reflection reponse containing the given symbol, if it is exposed by a configured service
-      """
-      @spec get_by_symbol(binary()) :: {:ok, GrpcReflection.descriptor_t()} | {:error, binary}
-      def get_by_symbol(symbol) do
-        GrpcReflection.Service.Agent.get_by_symbol(@cfg, symbol)
-      end
-
-      @doc """
-      Get the reflection response for the named file, if it is exposed by a configured service
-      """
-      @spec get_by_filename(binary()) :: {:ok, GrpcReflection.descriptor_t()} | {:error, binary}
-      def get_by_filename(filename) do
-        GrpcReflection.Service.Agent.get_by_filename(@cfg, filename)
-      end
-
-      @doc """
-      Get the extension numbers for the given type, if it is exposed by a configured service
-      """
-      @spec get_extension_numbers_by_type(module()) :: {:ok, list(integer())} | {:error, binary}
-      def get_extension_numbers_by_type(mod) do
-        GrpcReflection.Service.Agent.get_extension_numbers_by_type(@cfg, mod)
-      end
-
-      @doc """
-      Get the reflection response for the given extension, if it is exposed by a configured service
-      """
-      @spec get_by_extension(binary()) :: {:ok, GrpcReflection.descriptor_t()} | {:error, binary}
-      def get_by_extension(containing_type) do
-        GrpcReflection.Service.Agent.get_by_extension(@cfg, containing_type)
-      end
-
-      @doc """
-      A runtime configuration option for setting the services
-      """
-      @spec put_services(list(module())) :: :ok | {:error, binary()}
-      def put_services(services) do
-        case GrpcReflection.Service.Builder.build_reflection_tree(services) do
-          %GrpcReflection.Service.Agent{} = state ->
-            GrpcReflection.Service.Agent.put_state(@cfg, state)
-
-          err ->
-            err
-        end
-      end
-
-      case unquote(version) do
-        :v1 ->
-          use GRPC.Server, service: Grpc.Reflection.V1.ServerReflection.Service
-
-          def server_reflection_info(request_stream, server) do
-            GrpcReflection.Server.V1.server_reflection_info(
-              __MODULE__,
-              request_stream,
-              server
-            )
-          end
-
-        :v1alpha ->
-          use GRPC.Server, service: Grpc.Reflection.V1alpha.ServerReflection.Service
-
-          def server_reflection_info(request_stream, server) do
-            GrpcReflection.Server.V1alpha.server_reflection_info(
-              __MODULE__,
-              request_stream,
-              server
-            )
-          end
-
-        _ ->
-          raise "Invalid version #{unquote(version)}, should be in [:v1, :v1alpha]"
-      end
+      use GrpcReflection.Server, unquote(opts)
     end
   end
 

--- a/lib/grpc_reflection/server.ex
+++ b/lib/grpc_reflection/server.ex
@@ -10,4 +10,98 @@ defmodule GrpcReflection.Server do
   ### v1
   The current spec for reflection support within GRPC.
   """
+
+  @type descriptor_t ::
+          %Google.Protobuf.DescriptorProto{} | %Google.Protobuf.ServiceDescriptorProto{}
+
+  # credo:disable-for-next-line
+  defmacro __using__(opts) when is_list(opts) do
+    services = Keyword.get(opts, :services, [])
+    version = Keyword.get(opts, :version, :none)
+
+    quote do
+      @cfg {__MODULE__, unquote(services)}
+
+      @doc """
+      Get the current list of configured services
+      """
+      @spec list_services :: list(binary)
+      def list_services do
+        GrpcReflection.Service.Agent.list_services(@cfg)
+      end
+
+      @doc """
+      Get the reflection reponse containing the given symbol, if it is exposed by a configured service
+      """
+      @spec get_by_symbol(binary()) :: {:ok, GrpcReflection.descriptor_t()} | {:error, binary}
+      def get_by_symbol(symbol) do
+        GrpcReflection.Service.Agent.get_by_symbol(@cfg, symbol)
+      end
+
+      @doc """
+      Get the reflection response for the named file, if it is exposed by a configured service
+      """
+      @spec get_by_filename(binary()) :: {:ok, GrpcReflection.descriptor_t()} | {:error, binary}
+      def get_by_filename(filename) do
+        GrpcReflection.Service.Agent.get_by_filename(@cfg, filename)
+      end
+
+      @doc """
+      Get the extension numbers for the given type, if it is exposed by a configured service
+      """
+      @spec get_extension_numbers_by_type(module()) :: {:ok, list(integer())} | {:error, binary}
+      def get_extension_numbers_by_type(mod) do
+        GrpcReflection.Service.Agent.get_extension_numbers_by_type(@cfg, mod)
+      end
+
+      @doc """
+      Get the reflection response for the given extension, if it is exposed by a configured service
+      """
+      @spec get_by_extension(binary()) :: {:ok, GrpcReflection.descriptor_t()} | {:error, binary}
+      def get_by_extension(containing_type) do
+        GrpcReflection.Service.Agent.get_by_extension(@cfg, containing_type)
+      end
+
+      @doc """
+      A runtime configuration option for setting the services
+      """
+      @spec put_services(list(module())) :: :ok | {:error, binary()}
+      def put_services(services) do
+        case GrpcReflection.Service.Builder.build_reflection_tree(services) do
+          %GrpcReflection.Service.Agent{} = state ->
+            GrpcReflection.Service.Agent.put_state(@cfg, state)
+
+          err ->
+            err
+        end
+      end
+
+      case unquote(version) do
+        :v1 ->
+          use GRPC.Server, service: Grpc.Reflection.V1.ServerReflection.Service
+
+          def server_reflection_info(request_stream, server) do
+            GrpcReflection.Server.V1.server_reflection_info(
+              __MODULE__,
+              request_stream,
+              server
+            )
+          end
+
+        :v1alpha ->
+          use GRPC.Server, service: Grpc.Reflection.V1alpha.ServerReflection.Service
+
+          def server_reflection_info(request_stream, server) do
+            GrpcReflection.Server.V1alpha.server_reflection_info(
+              __MODULE__,
+              request_stream,
+              server
+            )
+          end
+
+        _ ->
+          raise "Invalid version #{unquote(version)}, should be in [:v1, :v1alpha]"
+      end
+    end
+  end
 end

--- a/lib/grpc_reflection/service/agent.ex
+++ b/lib/grpc_reflection/service/agent.ex
@@ -10,7 +10,7 @@ defmodule GrpcReflection.Service.Agent do
 
   defstruct services: [], files: %{}, symbols: %{}, extensions: %{}
 
-  @type descriptor_t :: GrpcReflection.descriptor_t()
+  @type descriptor_t :: GrpcReflection.Server.descriptor_t()
   @type cfg_t :: {atom(), list(atom)}
   @type t :: %__MODULE__{
           services: list(module()),

--- a/lib/grpc_reflection/supervisor.ex
+++ b/lib/grpc_reflection/supervisor.ex
@@ -1,0 +1,35 @@
+defmodule GrpcReflection.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl Supervisor
+  def init(opts) do
+    children = [
+      %{
+        id: OneOffTask,
+        start: {Task, :start_link, [__MODULE__, :one_off_task, []]},
+        type: :worker,
+        restart: :temporary
+      },
+      %{
+        id: GrpcReflection.DynamicSupervisor,
+        start: {GrpcReflection.DynamicSupervisor, :start_link, [opts]},
+        type: :supervisor,
+        restart: :permanent
+      }
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  @doc false
+  def one_off_task do
+    Protobuf.load_extensions()
+    :ignore
+  end
+end

--- a/test/grpc_reflection_test.exs
+++ b/test/grpc_reflection_test.exs
@@ -4,7 +4,7 @@ defmodule GrpcReflection.Test do
   use GrpcCase
 
   defmodule Service do
-    use GrpcReflection, version: :v1
+    use GrpcReflection.Server, version: :v1
   end
 
   test "adding a service changes responses" do

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -1,6 +1,6 @@
 defmodule GrpcReflection.TestEndpoint do
   defmodule V1Server do
-    use GrpcReflection,
+    use GrpcReflection.Server,
       version: :v1,
       services: [
         Helloworld.Greeter.Service,
@@ -16,7 +16,7 @@ defmodule GrpcReflection.TestEndpoint do
   end
 
   defmodule V1AlphaServer do
-    use GrpcReflection,
+    use GrpcReflection.Server,
       version: :v1alpha,
       services: [
         Helloworld.Greeter.Service,


### PR DESCRIPTION
In this PR:
- update the README to reflect recent additions in testing and proto2
- slim down the entry module by moving the `__using__` macro and server definitions to their own files
- put a proxying `__using__` in GrpcReflection so existing code works, but will get a nag

Change/deprecation:
While `use GrpcReflection,` will still function, it is now a nagging proxy for `use GrpcReflection.Server`, which is where the server macro is now located.  It nags by logging a warning during compilation.