### PR TITLE
[bugfix] Fix incorrect package name extraction for nested messages

### DIFF
--- a/examples/helloworld/priv/protos/helloworld.proto
+++ b/examples/helloworld/priv/protos/helloworld.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "io.grpc.examples.helloworld";
@@ -17,22 +17,11 @@ service Greeter {
 
 // The request message containing the user's name.
 message HelloRequest {
-  optional string name = 1;
-
-  message Payload {
-    optional string data = 1;
-  }
-
-  optional Payload payload = 2;
+  string name = 1;
 }
 
 // The response message containing the greetings
 message HelloReply {
-  optional string message = 1;
-  optional google.protobuf.Timestamp today = 2;
-  extensions 100 to 199;
-}
-
-extend HelloReply {
-  optional string language = 100;
+  string message = 1;
+  google.protobuf.Timestamp today = 2;
 }

--- a/examples/helloworld/priv/protos/helloworld.proto
+++ b/examples/helloworld/priv/protos/helloworld.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+syntax = "proto2";
 
 option java_multiple_files = true;
 option java_package = "io.grpc.examples.helloworld";
@@ -17,11 +17,22 @@ service Greeter {
 
 // The request message containing the user's name.
 message HelloRequest {
-  string name = 1;
+  optional string name = 1;
+
+  message Payload {
+    optional string data = 1;
+  }
+
+  optional Payload payload = 2;
 }
 
 // The response message containing the greetings
 message HelloReply {
-  string message = 1;
-  google.protobuf.Timestamp today = 2;
+  optional string message = 1;
+  optional google.protobuf.Timestamp today = 2;
+  extensions 100 to 199;
+}
+
+extend HelloReply {
+  optional string language = 100;
 }

--- a/lib/grpc_reflection/service/builder.ex
+++ b/lib/grpc_reflection/service/builder.ex
@@ -108,7 +108,7 @@ defmodule GrpcReflection.Service.Builder do
        when extension_range != [] do
     unencoded_extension_payload = %Google.Protobuf.FileDescriptorProto{
       name: extension_file,
-      package: Util.get_package(mod, symbol),
+      package: Util.get_package(symbol),
       dependency: [symbol <> ".proto"],
       syntax: Util.get_syntax(mod)
     }
@@ -144,7 +144,7 @@ defmodule GrpcReflection.Service.Builder do
   defp process_extensions(_, _, _, _), do: {:ignore, {nil, nil}}
 
   defp process_common(name, module, descriptor) do
-    package = Util.get_package(module, name)
+    package = Util.get_package(name)
 
     dependencies =
       descriptor

--- a/lib/grpc_reflection/service/builder.ex
+++ b/lib/grpc_reflection/service/builder.ex
@@ -108,7 +108,7 @@ defmodule GrpcReflection.Service.Builder do
        when extension_range != [] do
     unencoded_extension_payload = %Google.Protobuf.FileDescriptorProto{
       name: extension_file,
-      package: Util.package_from_name(symbol),
+      package: Util.get_package(mod, symbol),
       dependency: [symbol <> ".proto"],
       syntax: Util.get_syntax(mod)
     }
@@ -144,7 +144,7 @@ defmodule GrpcReflection.Service.Builder do
   defp process_extensions(_, _, _, _), do: {:ignore, {nil, nil}}
 
   defp process_common(name, module, descriptor) do
-    package = Util.package_from_name(name)
+    package = Util.get_package(module, name)
 
     dependencies =
       descriptor

--- a/test/builder/util_test.exs
+++ b/test/builder/util_test.exs
@@ -10,8 +10,18 @@ defmodule GrpcReflection.Service.Builder.UtilTest do
   end
 
   describe "common utils" do
-    test "get package from module name" do
-      assert "a.b" == Util.package_from_name("a.b.CService")
+    test "get package from module" do
+      assert "testserviceV3" ==
+               Util.get_package(TestserviceV3.TestRequest, "testserviceV3.TestRequest")
+
+      assert "testserviceV3" ==
+               Util.get_package(
+                 TestserviceV3.TestRequest.Payload.Location,
+                 "testserviceV3.TestRequest.Payload.Location"
+               )
+
+      assert "testserviceV3" ==
+               Util.get_package(TestserviceV3.TestService.Service, "testserviceV3.TestService")
     end
 
     test "upcase_first" do

--- a/test/builder/util_test.exs
+++ b/test/builder/util_test.exs
@@ -12,16 +12,13 @@ defmodule GrpcReflection.Service.Builder.UtilTest do
   describe "common utils" do
     test "get package from module" do
       assert "testserviceV3" ==
-               Util.get_package(TestserviceV3.TestRequest, "testserviceV3.TestRequest")
+               Util.get_package("testserviceV3.TestRequest")
 
       assert "testserviceV3" ==
-               Util.get_package(
-                 TestserviceV3.TestRequest.Payload.Location,
-                 "testserviceV3.TestRequest.Payload.Location"
-               )
+               Util.get_package("testserviceV3.TestRequest.Payload.Location")
 
       assert "testserviceV3" ==
-               Util.get_package(TestserviceV3.TestService.Service, "testserviceV3.TestService")
+               Util.get_package("testserviceV3.TestService")
     end
 
     test "upcase_first" do
@@ -30,6 +27,17 @@ defmodule GrpcReflection.Service.Builder.UtilTest do
 
     test "downcase_first" do
       assert "hello" == Util.downcase_first("Hello")
+    end
+
+    test "convert symbol to module succeed" do
+      assert TestserviceV3.TestRequest ==
+               Util.convert_symbol_to_module("testserviceV3.TestRequest")
+    end
+
+    test "convert symbol to module fail" do
+      assert_raise ArgumentError, fn ->
+        Util.convert_symbol_to_module("testservice.TestRequest.Payload.Location")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
The `package_from_name/1` method in `Builder.Util` currently extracts an incorrect package name when given a nested message name.

For example:
```
>  Util.package_from_name("testServiceV3.TestRequest.Payload")
"testServiceV3.TestRequest"
```
It's supposed to return:  `testServiceV3`

This PR fixes the issue by keeping only the outermost module component as the package name for any nested message input.

fixes #20 