### PR TITLE
Throw error when agent cannot be started

### DIFF
--- a/lib/grpc_reflection/service/agent.ex
+++ b/lib/grpc_reflection/service/agent.ex
@@ -63,8 +63,9 @@ defmodule GrpcReflection.Service.Agent do
 
   defp start_agent_on_first_call({name, services}) do
     # lazy start agent on call
-    if match?({:ok, _}, GrpcReflection.DynamicSupervisor.start_child(name, services)) do
-      Logger.info("Started reflection agent #{name}")
+    case GrpcReflection.DynamicSupervisor.start_child(name, services) do
+      {:ok, _} -> Logger.info("Started reflection agent #{name}")
+      {:error, {:already_started, _}} -> :ok
     end
 
     name


### PR DESCRIPTION
Previously if there's an error when starting an agent, the error is effectively silenced. I'm guessing this is to suppress `already_started` "errors". Unfortunately this also suppress any error

With this change, `already_started` will be ignored, but any other error will blow up, making it easy to see what went wrong. I considered logging an error and continuing, but it's simpler to blow up, and feels aligned with "let it crash"