### PR TITLE
Compatibility with Elixir v1.16

### DIFF
--- a/lib/grpc_reflection/service/builder/util.ex
+++ b/lib/grpc_reflection/service/builder/util.ex
@@ -8,7 +8,7 @@ defmodule GrpcReflection.Service.Builder.Util do
   @type_message Map.fetch!(Google.Protobuf.FieldDescriptorProto.Type.mapping(), :TYPE_MESSAGE)
 
   def get_package(symbol) do
-    parent_symbol = symbol |> String.split(".") |> Enum.slice(0..-2) |> Enum.join(".")
+    parent_symbol = symbol |> String.split(".") |> Enum.slice(0..-2//1) |> Enum.join(".")
 
     try do
       parent_module = convert_symbol_to_module(parent_symbol)

--- a/lib/grpc_reflection/service/builder/util.ex
+++ b/lib/grpc_reflection/service/builder/util.ex
@@ -125,12 +125,15 @@ defmodule GrpcReflection.Service.Builder.Util do
         module.__rpc_calls__()
         |> Enum.find(fn
           {_, _, _} -> true
+          {_, _, _, _} -> true
           _ -> false
         end)
         |> then(fn
           nil -> "proto2"
           {_, {req, _}, _} -> get_syntax(req)
+          {_, {req, _}, _, _} -> get_syntax(req)
           {_, _, {req, _}} -> get_syntax(req)
+          {_, _, {req, _}, _} -> get_syntax(req)
         end)
 
       true ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule GrpcReflection.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.2"
   @source_url "https://github.com/elixir-grpc/grpc-reflection"
   @description "gRPC reflection server for Elixir"
 


### PR DESCRIPTION
In [Elixir v1.16](https://elixirforum.com/t/elixir-v1-16-0-released/60530), `Enum.slice/2` no longer supports ranges with negative steps. This PR updates our usage of `Enum.slice/2` to be compatible with these changes. We've replaced the negative step ranges with the recommended `first..last//1` format. This ensures that our code base remains up-to-date and avoids redundant warning logs.

BTW, test cases failed in CI workflow due to a breaking change of `@rpc_calls` in grpc v0.8+. This PR fixed the issue too.
