### PR TITLE
we are sensitive to loaded modules, ensure_loaded while building

### DIFF
--- a/lib/grpc_reflection/service/builder/util.ex
+++ b/lib/grpc_reflection/service/builder/util.ex
@@ -12,6 +12,7 @@ defmodule GrpcReflection.Service.Builder.Util do
 
     try do
       parent_module = convert_symbol_to_module(parent_symbol)
+      Code.ensure_loaded(parent_module)
 
       if function_exported?(parent_module, :descriptor, 0) do
         get_package(parent_symbol)


### PR DESCRIPTION
It may not be a major issue, but we cannot run our unit tests in isolation as the util for generating the package name is sensitive to what modules are currently loaded.

Instead of adding `ensure_all_loaded` to the afflicted test, this adds an `ensure_loaded` before checking for the function export soif the module exists we load and use it.