### PR TITLE
Chore/reproduce package problem

### DIFF
--- a/examples/helloworld/lib/greeter_server.ex
+++ b/examples/helloworld/lib/greeter_server.ex
@@ -13,4 +13,16 @@ defmodule Helloworld.Greeter.Server do
       today: %Google.Protobuf.Timestamp{seconds: seconds, nanos: nanos}
     }
   end
+
+  def get_spec(_request, _stream) do
+    %Example.Helloworld.HelloSpec{
+      message: "this is a spec",
+      spec: %Example.Helloworld.HelloSpec.Spec{
+        major: 0,
+        minor: 5,
+        patch: 6,
+        notes: "version notes"
+      }
+    }
+  end
 end

--- a/examples/helloworld/lib/greeter_server.ex
+++ b/examples/helloworld/lib/greeter_server.ex
@@ -1,14 +1,14 @@
 defmodule Helloworld.Greeter.Server do
-  use GRPC.Server, service: Helloworld.Greeter.Service
+  use GRPC.Server, service: Example.Helloworld.Greeter.Service
 
-  @spec say_hello(Helloworld.HelloRequest.t(), GRPC.Server.Stream.t()) ::
-          Helloworld.HelloReply.t()
+  @spec say_hello(Example.Helloworld.HelloRequest.t(), GRPC.Server.Stream.t()) ::
+          Example.Helloworld.HelloReply.t()
   def say_hello(request, _stream) do
     nanos_epoch = System.system_time() |> System.convert_time_unit(:native, :nanosecond)
     seconds = div(nanos_epoch, 1_000_000_000)
     nanos = nanos_epoch - seconds * 1_000_000_000
 
-    %Helloworld.HelloReply{
+    %Example.Helloworld.HelloReply{
       message: "Hello #{request.name}",
       today: %Google.Protobuf.Timestamp{seconds: seconds, nanos: nanos}
     }

--- a/examples/helloworld/lib/reflection_server.ex
+++ b/examples/helloworld/lib/reflection_server.ex
@@ -1,5 +1,5 @@
 defmodule Helloworld.Reflection.Server do
   use GrpcReflection.Server,
     version: :v1,
-    services: [Helloworld.Greeter.Service]
+    services: [Example.Helloworld.Greeter.Service]
 end

--- a/examples/helloworld/priv/protos/helloworld.proto
+++ b/examples/helloworld/priv/protos/helloworld.proto
@@ -6,13 +6,15 @@ option java_outer_classname = "HelloWorldProto";
 option objc_class_prefix = "HLW";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
 
-package helloworld;
+package example.helloworld;
 
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
   rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc GetSpec (google.protobuf.Empty) returns (HelloSpec) {}
 }
 
 // The request message containing the user's name.
@@ -24,4 +26,16 @@ message HelloRequest {
 message HelloReply {
   string message = 1;
   google.protobuf.Timestamp today = 2;
+}
+
+message HelloSpec {
+  string message = 1;
+  Spec spec = 2;
+
+  message Spec {
+    int32 major = 1;
+    int32 minor = 2;
+    int32 patch = 3;
+    string notes = 4;
+  }
 }

--- a/lib/grpc_reflection/server.ex
+++ b/lib/grpc_reflection/server.ex
@@ -38,12 +38,22 @@ defmodule GrpcReflection.Server do
       @spec get_by_symbol(binary()) ::
               {:ok, GrpcReflection.Server.descriptor_t()} | {:error, binary}
       def get_by_symbol(symbol) do
-        {:ok, %{file_descriptor_proto: [proto]} = resp} = Service.get_by_symbol(@cfg, symbol)
+        {:ok, %{file_descriptor_proto: [proto]}} = resp = Service.get_by_symbol(@cfg, symbol)
+
         IO.puts("~~~")
         IO.inspect(symbol)
-        IO.inspect(Google.Protobuf.FileDescriptorProto.decode(proto).package)
 
-        {:ok, resp}
+        if symbol == "example.helloworld.HelloSpec.Spec" do
+          proto = Google.Protobuf.FileDescriptorProto.decode(proto)
+          IO.inspect(proto.package)
+          # proto = %{proto | package: "example.helloWorld.HelloSpec"}
+          # proto = %{proto | package: "example.helloWorld.HelloSpec.Spec"}
+          # IO.inspect(proto.package)
+          proto = Google.Protobuf.FileDescriptorProto.encode(proto)
+          {:ok, %{file_descriptor_proto: [proto]}}
+        else
+          resp
+        end
       end
 
       @doc """

--- a/lib/grpc_reflection/server.ex
+++ b/lib/grpc_reflection/server.ex
@@ -46,9 +46,8 @@ defmodule GrpcReflection.Server do
         if symbol == "example.helloworld.HelloSpec.Spec" do
           proto = Google.Protobuf.FileDescriptorProto.decode(proto)
           IO.inspect(proto.package)
-          # proto = %{proto | package: "example.helloWorld.HelloSpec"}
-          # proto = %{proto | package: "example.helloWorld.HelloSpec.Spec"}
-          # IO.inspect(proto.package)
+          proto = %{proto | package: "example.helloworld.HelloSpec"}
+          IO.inspect(proto.package)
           proto = Google.Protobuf.FileDescriptorProto.encode(proto)
           {:ok, %{file_descriptor_proto: [proto]}}
         else

--- a/lib/grpc_reflection/server.ex
+++ b/lib/grpc_reflection/server.ex
@@ -38,7 +38,12 @@ defmodule GrpcReflection.Server do
       @spec get_by_symbol(binary()) ::
               {:ok, GrpcReflection.Server.descriptor_t()} | {:error, binary}
       def get_by_symbol(symbol) do
-        Service.get_by_symbol(@cfg, symbol)
+        {:ok, %{file_descriptor_proto: [proto]} = resp} = Service.get_by_symbol(@cfg, symbol)
+        IO.puts("~~~")
+        IO.inspect(symbol)
+        IO.inspect(Google.Protobuf.FileDescriptorProto.decode(proto).package)
+
+        {:ok, resp}
       end
 
       @doc """

--- a/lib/grpc_reflection/service/builder/util.ex
+++ b/lib/grpc_reflection/service/builder/util.ex
@@ -12,6 +12,7 @@ defmodule GrpcReflection.Service.Builder.Util do
 
     try do
       parent_module = convert_symbol_to_module(parent_symbol)
+      Code.ensure_loaded(parent_module)
 
       if function_exported?(parent_module, :descriptor, 0) do
         get_package(parent_symbol)


### PR DESCRIPTION
When we have nested message definitions, grpcurl is unable to resolve some symbols.  I have found that by injecting a different package name it will resolve fine, so there may be an issue in how we calculate the package names of modules.

This PR demonstrates this in the example app.

1. regenerate the example protos `./generate_protos.sh`
1. run the example app `iex -S mix`
1. some messages resolve
    ```bash
    ❯ grpcurl -plaintext 127.0.0.1:50051 describe example.helloworld.HelloSpec     
    example.helloworld.HelloSpec is a message:
    message HelloSpec {
      string message = 1;
      .example.helloworld.HelloSpec.Spec spec = 2;
      message Spec {
        int32 major = 1;
        int32 minor = 2;
        int32 patch = 3;
        string notes = 4;
      }
    }
    ```
1. nested message does not resolve (when you comment out the package overwrite code in server.ex)
    ```bash
    ❯ grpcurl -plaintext 127.0.0.1:50051 describe example.helloworld.HelloSpec.Spec
    Failed to resolve symbol "example.helloworld.HelloSpec.Spec": Symbol not found: example.helloworld.HelloSpec.Spec
    ```
    
This may be related to https://github.com/elixir-grpc/grpc-reflection/issues/20