### PR TITLE
Use Macro.camelize/1

### DIFF
--- a/lib/grpc_reflection/service/builder/util.ex
+++ b/lib/grpc_reflection/service/builder/util.ex
@@ -24,8 +24,6 @@ defmodule GrpcReflection.Service.Builder.Util do
     end
   end
 
-  def upcase_first(<<first::utf8, rest::binary>>), do: String.upcase(<<first::utf8>>) <> rest
-
   def downcase_first(<<first::utf8, rest::binary>>),
     do: String.downcase(<<first::utf8>>) <> rest
 

--- a/lib/grpc_reflection/service/builder/util.ex
+++ b/lib/grpc_reflection/service/builder/util.ex
@@ -103,7 +103,7 @@ defmodule GrpcReflection.Service.Builder.Util do
       name -> name
     end)
     |> String.split(".")
-    |> Enum.map(&upcase_first/1)
+    |> Enum.map(&Macro.camelize/1)
     |> Module.safe_concat()
   end
 

--- a/test/builder/util_test.exs
+++ b/test/builder/util_test.exs
@@ -21,10 +21,6 @@ defmodule GrpcReflection.Service.Builder.UtilTest do
                Util.get_package("testserviceV3.TestService")
     end
 
-    test "upcase_first" do
-      assert "Hello" == Util.upcase_first("hello")
-    end
-
     test "downcase_first" do
       assert "hello" == Util.downcase_first("Hello")
     end


### PR DESCRIPTION
Fixes a bug with package names that contain underscores like `package test_service.v1.FooBar`. This will generate a module named `TestService.V1.FooBar` in Elixir.

Currently if a package with underscore is used, it results in the following list `["Test_service", "V1", "FooBar"]` and fails `Module.safe_concat/1` because this atom does not exist. `Test_service` should be `TestService`.