### PR TITLE
35 failed to resolve symbol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "googleapis"]
+    path = examples/helloworld/priv/protos/googleapis
+    url = https://github.com/googleapis/googleapis.git

--- a/examples/helloworld/.gitignore
+++ b/examples/helloworld/.gitignore
@@ -21,5 +21,3 @@ erl_crash.dump
 /tmp
 
 /log
-
-*.pb.ex

--- a/examples/helloworld/generate_protos.sh
+++ b/examples/helloworld/generate_protos.sh
@@ -8,5 +8,13 @@ PROTOS=("
 ")
 
 for file in $PROTOS; do
-  protoc --elixir_opt=include_docs=true --elixir_out=plugins=grpc,gen_descriptors=true:./lib/protos --proto_path=priv/protos/ $file
+  mix protobuf.generate \
+    --output-path=./lib/protos \
+    --include-docs=true \
+    --generate-descriptors=true \
+    --include-path=priv/protos/ \
+    --include-path=./priv/protos/googleapis \
+    --plugin=ProtobufGenerate.Plugins.GRPC \
+    --one-file-per-module \
+    $file
 done

--- a/examples/helloworld/generate_protos.sh
+++ b/examples/helloworld/generate_protos.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-rm -rf ./lib/protos
-mkdir ./lib/protos
-
 PROTOS=("
     priv/protos/helloworld.proto
 ")

--- a/examples/helloworld/lib/protos/helloworld.pb.ex
+++ b/examples/helloworld/lib/protos/helloworld.pb.ex
@@ -1,0 +1,516 @@
+defmodule Helloworld.HelloRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "HelloRequest",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "name",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "name",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :name, 1, type: :string
+end
+
+defmodule Helloworld.HelloReply do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "HelloReply",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "message",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "message",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "today",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.Timestamp",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "today",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :message, 1, type: :string
+  field :today, 2, type: Google.Protobuf.Timestamp
+end
+
+defmodule Helloworld.Greeter.Service do
+  use GRPC.Service, name: "helloworld.Greeter", protoc_gen_elixir_version: "0.12.0"
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.FileDescriptorProto{
+      name: "helloworld.proto",
+      package: "helloworld",
+      dependency: ["google/protobuf/timestamp.proto"],
+      message_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "HelloRequest",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "name",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "name",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: nil,
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.DescriptorProto{
+          name: "HelloReply",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "message",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "message",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "today",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_MESSAGE,
+              type_name: ".google.protobuf.Timestamp",
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "today",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: nil,
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      service: [
+        %Google.Protobuf.ServiceDescriptorProto{
+          name: "Greeter",
+          method: [
+            %Google.Protobuf.MethodDescriptorProto{
+              name: "SayHello",
+              input_type: ".helloworld.HelloRequest",
+              output_type: ".helloworld.HelloReply",
+              options: %Google.Protobuf.MethodOptions{
+                deprecated: false,
+                idempotency_level: :IDEMPOTENCY_UNKNOWN,
+                uninterpreted_option: [],
+                __pb_extensions__: %{},
+                __unknown_fields__: []
+              },
+              client_streaming: false,
+              server_streaming: false,
+              __unknown_fields__: []
+            }
+          ],
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      extension: [],
+      options: %Google.Protobuf.FileOptions{
+        java_package: "io.grpc.examples.helloworld",
+        java_outer_classname: "HelloWorldProto",
+        optimize_for: :SPEED,
+        java_multiple_files: true,
+        go_package: nil,
+        cc_generic_services: false,
+        java_generic_services: false,
+        py_generic_services: false,
+        java_generate_equals_and_hash: nil,
+        deprecated: false,
+        java_string_check_utf8: false,
+        cc_enable_arenas: true,
+        objc_class_prefix: "HLW",
+        csharp_namespace: nil,
+        swift_prefix: nil,
+        php_class_prefix: nil,
+        php_namespace: nil,
+        php_generic_services: false,
+        php_metadata_namespace: nil,
+        ruby_package: nil,
+        uninterpreted_option: [],
+        __pb_extensions__: %{},
+        __unknown_fields__: []
+      },
+      source_code_info: %Google.Protobuf.SourceCodeInfo{
+        location: [
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [],
+            span: [0, 0, 26, 1],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: ~c"\f",
+            span: [0, 0, 18],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: ~c"\b",
+            span: [2, 0, 34],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: ~c"\b\n",
+            span: [2, 0, 34],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: ~c"\b",
+            span: [3, 0, 52],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [8, 1],
+            span: [3, 0, 52],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: ~c"\b",
+            span: [4, 0, 48],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: ~c"\b\b",
+            span: [4, 0, 48],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: ~c"\b",
+            span: [5, 0, 33],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: ~c"\b$",
+            span: [5, 0, 33],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [3, 0],
+            span: [7, 0, 41],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [2],
+            span: [9, 0, 19],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [6, 0],
+            span: [12, 0, 15, 1],
+            leading_comments: " The greeting service definition.\n",
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [6, 0, 1],
+            span: [12, 8, 15],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [6, 0, 2, 0],
+            span: [14, 2, 53],
+            leading_comments: " Sends a greeting\n",
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [6, 0, 2, 0, 1],
+            span: [14, 6, 14],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [6, 0, 2, 0, 2],
+            span: [14, 16, 28],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [6, 0, 2, 0, 3],
+            span: [14, 39, 49],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 0],
+            span: [18, 0, 20, 1],
+            leading_comments: " The request message containing the user's name.\n",
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 0, 1],
+            span: [18, 8, 20],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 0, 2, 0],
+            span: [19, 2, 18],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 0, 2, 0, 5],
+            span: [19, 2, 8],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 0, 2, 0, 1],
+            span: [19, 9, 13],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 0, 2, 0, 3],
+            span: [19, 16, 17],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1],
+            span: [23, 0, 26, 1],
+            leading_comments: " The response message containing the greetings\n",
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1, 1],
+            span: [23, 8, 18],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1, 2, 0],
+            span: [24, 2, 21],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1, 2, 0, 5],
+            span: [24, 2, 8],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1, 2, 0, 1],
+            span: [24, 9, 16],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1, 2, 0, 3],
+            span: [24, 19, 20],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1, 2, 1],
+            span: [25, 2, 38],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1, 2, 1, 6],
+            span: [25, 2, 27],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1, 2, 1, 1],
+            span: [25, 28, 33],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          },
+          %Google.Protobuf.SourceCodeInfo.Location{
+            path: [4, 1, 2, 1, 3],
+            span: [25, 36, 37],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: [],
+            __unknown_fields__: []
+          }
+        ],
+        __unknown_fields__: []
+      },
+      public_dependency: [],
+      weak_dependency: [],
+      syntax: "proto3",
+      edition: nil,
+      __unknown_fields__: []
+    }
+  end
+
+  rpc :SayHello, Helloworld.HelloRequest, Helloworld.HelloReply
+end
+
+defmodule Helloworld.Greeter.Stub do
+  use GRPC.Stub, service: Helloworld.Greeter.Service
+end

--- a/examples/helloworld/mix.exs
+++ b/examples/helloworld/mix.exs
@@ -21,7 +21,9 @@ defmodule Helloworld.Mixfile do
       {:grpc, "~> 0.7"},
       {:grpc_reflection, path: "../.."},
       {:protobuf, "~> 0.11"},
-      {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
+      {:google_protos, "~> 0.4.0"},
+      {:protobuf_generate, "~> 0.1.0"}
     ]
   end
 end

--- a/examples/helloworld/mix.lock
+++ b/examples/helloworld/mix.lock
@@ -9,6 +9,7 @@
   "hpax": {:hex, :hpax, "0.1.2", "09a75600d9d8bbd064cdd741f21fc06fc1f4cf3d0fcc335e5aa19be1a7235c84", [:mix], [], "hexpm", "2c87843d5a23f5f16748ebe77969880e29809580efdaccd615cd3bed628a8c13"},
   "mint": {:hex, :mint, "1.5.1", "8db5239e56738552d85af398798c80648db0e90f343c8469f6c6d8898944fb6f", [:mix], [{:castore, "~> 0.1.0 or ~> 1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:hpax, "~> 0.1.1", [hex: :hpax, repo: "hexpm", optional: false]}], "hexpm", "4a63e1e76a7c3956abd2c72f370a0d0aecddc3976dea5c27eccbecfa5e7d5b1e"},
   "protobuf": {:hex, :protobuf, "0.12.0", "58c0dfea5f929b96b5aa54ec02b7130688f09d2de5ddc521d696eec2a015b223", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "75fa6cbf262062073dd51be44dd0ab940500e18386a6c4e87d5819a58964dc45"},
+  "protobuf_generate": {:hex, :protobuf_generate, "0.1.2", "45b9a9ae8606333cdea993ceaaecd799d206cdfe23348d37c06207eac76cbee6", [:mix], [{:protobuf, "~> 0.12", [hex: :protobuf, repo: "hexpm", optional: false]}], "hexpm", "55b0ff8385703317ca90e1bd30a2ece99e80ae0c73e6ebcfb374e84e57870d61"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
 }

--- a/lib/grpc_reflection/service/builder.ex
+++ b/lib/grpc_reflection/service/builder.ex
@@ -41,8 +41,8 @@ defmodule GrpcReflection.Service.Builder do
     # protobuf_generate populates services with file_descriptors
     case service.descriptor() do
       %FileDescriptorProto{service: [proto]} ->
-        # TODO we should read and use the file descriptor directly instead
-        # of dropping relevant data nd trying to discover it
+        # we should read and use the file descriptor directly instead
+        # of dropping relevant data and trying to discover it
         process_service_descriptor(name, proto, syntax)
 
       %ServiceDescriptorProto{} = proto ->

--- a/mix.exs
+++ b/mix.exs
@@ -44,8 +44,7 @@ defmodule GrpcReflection.MixProject do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:grpc, "~> 0.7"},
       {:protobuf, "~> 0.11"},
-      {:google_protos, "~> 0.4.0"},
-      {:protobuf_generate, "~> 0.1.0"}
+      {:google_protos, "~> 0.4.0"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,8 @@ defmodule GrpcReflection.MixProject do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:grpc, "~> 0.7"},
       {:protobuf, "~> 0.11"},
-      {:google_protos, "~> 0.4.0"}
+      {:google_protos, "~> 0.4.0"},
+      {:protobuf_generate, "~> 0.1.0"}
     ]
   end
 


### PR DESCRIPTION
The proto generator `protobuf_generate` assigns services with a FileDescriptorProto instead of just a ServiceDescriptorProto.  While this is arguably better, and has information we should be able to leverage, this PR simply unwraps the extra layer at the service entry point and performs the normal dynamic discovery that it does for `protobuf_elixir`