### PR TITLE
disable cron CI run, github disables CI when unchanged for too long

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
   validate_1_13:
     name: Validate PR against 1.13
     runs-on: ubuntu-latest
-    if: github.event.schedule != '0 6 * * 1'
     steps:
       - uses: actions/checkout@v4
 
@@ -47,7 +46,6 @@ jobs:
   validate_1_14:
     name: Validate PR against 1.14
     runs-on: ubuntu-latest
-    if: github.event.schedule != '0 6 * * 1'
     steps:
       - uses: actions/checkout@v4
 
@@ -80,7 +78,6 @@ jobs:
   validate_1_15:
     name: Validate PR against 1.15
     runs-on: ubuntu-latest
-    if: github.event.schedule != '0 6 * * 1'
     steps:
       - uses: actions/checkout@v4
 
@@ -146,7 +143,6 @@ jobs:
   validate_unlocked:
     name: Validate Code With Unlocked Dependencies
     runs-on: ubuntu-latest
-    if: github.event.schedule == '0 6 * * 1'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "0 6 * * 1"
 
 env:
   MIX_ENV: test


### PR DESCRIPTION
Remove the cron schedule for CI.  Github disabled the CI runs after several scheduled runs and no changes to the codebase.

This can present additional issues / needed fixes when PRs are opened, but we will just have to deal with that then.