### PR TITLE
fix: corrected spelling from accoring to according

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Server reflection allows servers to assist clients in runtime construction of requests without having stub information precompiled into the client.
 
-Accoring to the [GRPC Server Reflection Protocol
+According to the [GRPC Server Reflection Protocol
 ](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md), the primary usecase for server reflection is to write (typically) command line debugging tools for talking to a grpc server. In particular, such a tool will take in a method and a payload (in human readable text format) send it to the server (typically in binary proto wire format), and then take the response and decode it to text to present to the user.
 
 GrpcReflection, implemented as a gRPC server using `grpc-elixir`, adds reflection support to a `grpc-elixir`  based application.


### PR DESCRIPTION
this pr contains:
 a correction on spelling mistakes in the docs
 from `accoring` to `according`