### PR TITLE
remove elixir 1.13 and otp 24 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,31 +16,29 @@ jobs:
     name: "Check elixir+otp versions"
     strategy:
       matrix:
+        # https://endoflife.date/elixir
+        # elixir >= 1.14
+        # https://endoflife.date/erlang
+        # erlang >= 25
+        # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
+        # elixir-otp version pairs defined
         runtime: [
-            # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
-            # running latest ubuntu, OTP >= 24 only
-            # 1.13.x
-            { elixir: 1.13.x, otp: 24.3.x },
-            { elixir: 1.13.x, otp: 25.3.x },
             # 1.14.x
-            { elixir: 1.14.x, otp: 24.3.x },
-            { elixir: 1.14.x, otp: 25.3.x },
+            { elixir: 1.14.x, otp: 25.x },
             # 1.15.x
-            { elixir: 1.15.x, otp: 24.3.x },
-            { elixir: 1.15.x, otp: 25.3.x },
-            { elixir: 1.15.x, otp: 26.2.x },
+            { elixir: 1.15.x, otp: 25.x },
+            { elixir: 1.15.x, otp: 26.x },
             # 1.16.x
-            { elixir: 1.16.x, otp: 24.3.x },
-            { elixir: 1.16.x, otp: 25.3.x },
-            { elixir: 1.16.x, otp: 26.2.x },
+            { elixir: 1.16.x, otp: 25.x },
+            { elixir: 1.16.x, otp: 26.x },
             # 1.17.x
-            { elixir: 1.17.x, otp: 25.3.x },
-            { elixir: 1.17.x, otp: 26.2.x },
-            { elixir: 1.17.x, otp: 27.2.x },
+            { elixir: 1.17.x, otp: 25.x },
+            { elixir: 1.17.x, otp: 26.x },
+            { elixir: 1.17.x, otp: 27.x },
             # 1.18.x
-            { elixir: 1.18.x, otp: 25.3.x },
-            { elixir: 1.18.x, otp: 26.2.x },
-            { elixir: 1.18.x, otp: 27.2.x },
+            { elixir: 1.18.x, otp: 25.x },
+            { elixir: 1.18.x, otp: 26.x },
+            { elixir: 1.18.x, otp: 27.x },
           ]
     runs-on: ubuntu-latest
     steps:
@@ -82,7 +80,7 @@ jobs:
         id: beam
         uses: erlef/setup-beam@v1
         with:
-          otp-version: 27.2.x
+          otp-version: 27.x
           elixir-version: 1.18.x
 
       - name: Restore dependencies cache
@@ -142,7 +140,7 @@ jobs:
         id: beam
         uses: erlef/setup-beam@v1
         with:
-          otp-version: 27.2.x
+          otp-version: 27.x
           elixir-version: 1.18.x
 
       - name: Restore dependencies cache
@@ -174,7 +172,7 @@ jobs:
         id: beam
         uses: erlef/setup-beam@v1
         with:
-          otp-version: 27.2.x
+          otp-version: 27.x
           elixir-version: 1.18.x
 
       - name: Build and Test


### PR DESCRIPTION
Elixir 1.13 and OTP 24 no longer receive security updates and are effectively unsupported runtimes.
This PR removes them from the CI test matrix.