### PR TITLE
Don't build symbols we already have in the state

### DIFF
--- a/lib/grpc_reflection/service/builder.ex
+++ b/lib/grpc_reflection/service/builder.ex
@@ -90,7 +90,7 @@ defmodule GrpcReflection.Service.Builder do
         symbol: Enum.find(fields, fn f -> f.name == name end).type_name
       }
     end)
-    |> Enum.reject(fn %{symbol: s} -> s == nil end)
+    |> Enum.reject(fn %{symbol: s} -> is_nil(s) or State.has_symbol?(state, s) end)
     |> Enum.reduce(state, fn %{mod: mod, symbol: symbol}, state ->
       symbol = Util.trim_symbol(symbol)
 

--- a/priv/protos/recursive_message.proto
+++ b/priv/protos/recursive_message.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package recursive_message;
+
+service Service {
+  rpc call (Request) returns (Reply) {}
+}
+
+message Request {
+  Reply reply = 1;
+}
+
+message Reply {
+  Request request = 1;
+}

--- a/test/service/builder_test.exs
+++ b/test/service/builder_test.exs
@@ -167,4 +167,21 @@ defmodule GrpcReflection.Service.BuilderTest do
     assert {:ok, tree} = Builder.build_reflection_tree([WrappedService])
     assert %State{services: [WrappedService]} = tree
   end
+
+  test "handles a recursive message structure" do
+    assert {:ok, tree} = Builder.build_reflection_tree([RecursiveMessage.Service.Service])
+
+    assert tree.files |> Map.keys() |> Enum.sort() == [
+             "recursive_message.Reply.proto",
+             "recursive_message.Request.proto",
+             "recursive_message.Service.proto"
+           ]
+
+    assert tree.symbols |> Map.keys() |> Enum.sort() == [
+             "recursive_message.Reply",
+             "recursive_message.Request",
+             "recursive_message.Service",
+             "recursive_message.Service.call"
+           ]
+  end
 end

--- a/test/support/protos/recursive_message.pb.ex
+++ b/test/support/protos/recursive_message.pb.ex
@@ -1,0 +1,120 @@
+defmodule RecursiveMessage.Request do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Request",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "reply",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".recursive_message.Reply",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "reply",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :reply, 1, type: RecursiveMessage.Reply
+end
+
+defmodule RecursiveMessage.Reply do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Reply",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "request",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".recursive_message.Request",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "request",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :request, 1, type: RecursiveMessage.Request
+end
+
+defmodule RecursiveMessage.Service.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "recursive_message.Service", protoc_gen_elixir_version: "0.14.1"
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.ServiceDescriptorProto{
+      name: "Service",
+      method: [
+        %Google.Protobuf.MethodDescriptorProto{
+          name: "call",
+          input_type: ".recursive_message.Request",
+          output_type: ".recursive_message.Reply",
+          options: %Google.Protobuf.MethodOptions{
+            deprecated: false,
+            idempotency_level: :IDEMPOTENCY_UNKNOWN,
+            features: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          client_streaming: false,
+          server_streaming: false,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      __unknown_fields__: []
+    }
+  end
+
+  rpc :call, RecursiveMessage.Request, RecursiveMessage.Reply
+end
+
+defmodule RecursiveMessage.Service.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: RecursiveMessage.Service.Service
+end


### PR DESCRIPTION
While building the reflection tree, the build resolution can get stuck in a loop with messages that refer to each-other.

The root cause is that we didn't check if we already had added the field symbol to the state before processing it.  Adding this check prevents the recursion problem and allows the build to complete the tree.