### PR TITLE
fix: downgrade reflection request logs to debug

### DIFF
--- a/lib/grpc_reflection/server/v1.ex
+++ b/lib/grpc_reflection/server/v1.ex
@@ -9,7 +9,7 @@ defmodule GrpcReflection.Server.V1 do
 
   def server_reflection_info(state_mod, request_stream, server) do
     Enum.map(request_stream, fn request ->
-      Logger.info("Received v1 reflection request: " <> inspect(request.message_request))
+      Logger.debug("Received v1 reflection request: " <> inspect(request.message_request))
 
       response =
         state_mod

--- a/lib/grpc_reflection/server/v1alpha.ex
+++ b/lib/grpc_reflection/server/v1alpha.ex
@@ -9,7 +9,7 @@ defmodule GrpcReflection.Server.V1alpha do
 
   def server_reflection_info(state_mod, request_stream, server) do
     Enum.map(request_stream, fn request ->
-      Logger.info("Received v1alpha reflection request: " <> inspect(request.message_request))
+      Logger.debug("Received v1alpha reflection request: " <> inspect(request.message_request))
 
       response =
         state_mod


### PR DESCRIPTION
- Every gRPC reflection request was logged at \`info\`, producing high-volume noise during normal operation — a client traversing a service schema with 20+ proto files generates 20+ log lines per connection with no actionable signal.
- Reflection requests are only useful context when actively debugging reflection issues, which is the intent of \`debug\` level.