### PR TITLE
Feature/no descriptor fallback

### DIFF
--- a/lib/grpc_reflection.ex
+++ b/lib/grpc_reflection.ex
@@ -2,7 +2,11 @@ defmodule GrpcReflection do
   @moduledoc """
   Reflection support for the grpc-elixir package
 
-  To use these servers, all protos must be compiled with the `gen_descriptors=true` option, as that is the source of truth for the reflection service.
+  Protos compiled with `gen_descriptors=true` provide the richest reflection output.
+  If that option is omitted, this library synthesizes descriptors from runtime module
+  metadata (`__message_props__`, `__rpc_calls__`). The synthesized path produces
+  equivalent output for standard gRPC reflection clients; only proto2 extensions and
+  custom proto options are unavailable without `gen_descriptors=true`.
 
   To turn on reflection in your application, do the following:
 

--- a/lib/grpc_reflection/service/builder.ex
+++ b/lib/grpc_reflection/service/builder.ex
@@ -69,7 +69,7 @@ defmodule GrpcReflection.Service.Builder do
   end
 
   defp trace_message_refs(state, parent_symbol, module) do
-    case module.descriptor() do
+    case get_descriptor(module) do
       %{field: fields} ->
         trace_message_fields(state, parent_symbol, module, fields)
 
@@ -79,7 +79,7 @@ defmodule GrpcReflection.Service.Builder do
   end
 
   defp trace_message_fields(state, parent_symbol, module, fields) do
-    nested_types = Util.get_nested_types(parent_symbol, module.descriptor())
+    nested_types = Util.get_nested_types(parent_symbol, get_descriptor(module))
 
     module.__message_props__().field_props
     |> Map.values()
@@ -176,9 +176,31 @@ defmodule GrpcReflection.Service.Builder do
   # generate descriptors.  Use this to potentially unwrap the service proto when dealing
   # with descriptors that could come from a service module.
   defp get_descriptor(module) do
-    case module.descriptor() do
-      %FileDescriptorProto{service: [proto]} -> proto
-      proto -> proto
+    if Code.ensure_loaded?(module) and function_exported?(module, :descriptor, 0) do
+      case module.descriptor() do
+        %FileDescriptorProto{service: [proto]} -> proto
+        proto -> proto
+      end
+    else
+      synthesize_descriptor(module)
+    end
+  end
+
+  defp synthesize_descriptor(module) do
+    Code.ensure_loaded?(module)
+
+    cond do
+      function_exported?(module, :__rpc_calls__, 0) ->
+        GrpcReflection.Service.Builder.Synthesizer.service_descriptor(module)
+
+      function_exported?(module, :mapping, 0) ->
+        GrpcReflection.Service.Builder.Synthesizer.enum_descriptor(module)
+
+      function_exported?(module, :__message_props__, 0) ->
+        GrpcReflection.Service.Builder.Synthesizer.message_descriptor(module)
+
+      true ->
+        raise "Module #{inspect(module)} has no descriptor/0 and cannot be synthesized"
     end
   end
 end

--- a/lib/grpc_reflection/service/builder.ex
+++ b/lib/grpc_reflection/service/builder.ex
@@ -176,13 +176,18 @@ defmodule GrpcReflection.Service.Builder do
   # generate descriptors.  Use this to potentially unwrap the service proto when dealing
   # with descriptors that could come from a service module.
   defp get_descriptor(module) do
-    if Code.ensure_loaded?(module) and function_exported?(module, :descriptor, 0) do
-      case module.descriptor() do
-        %FileDescriptorProto{service: [proto]} -> proto
-        proto -> proto
-      end
-    else
-      synthesize_descriptor(module)
+    cond do
+      not Code.ensure_loaded?(module) ->
+        raise "Module #{inspect(module)} is not loaded"
+
+      function_exported?(module, :descriptor, 0) ->
+        case module.descriptor() do
+          %FileDescriptorProto{service: [proto]} -> proto
+          proto -> proto
+        end
+
+      true ->
+        synthesize_descriptor(module)
     end
   end
 

--- a/lib/grpc_reflection/service/builder.ex
+++ b/lib/grpc_reflection/service/builder.ex
@@ -187,8 +187,6 @@ defmodule GrpcReflection.Service.Builder do
   end
 
   defp synthesize_descriptor(module) do
-    Code.ensure_loaded?(module)
-
     cond do
       function_exported?(module, :__rpc_calls__, 0) ->
         GrpcReflection.Service.Builder.Synthesizer.service_descriptor(module)
@@ -200,7 +198,10 @@ defmodule GrpcReflection.Service.Builder do
         GrpcReflection.Service.Builder.Synthesizer.message_descriptor(module)
 
       true ->
-        raise "Module #{inspect(module)} has no descriptor/0 and cannot be synthesized"
+        # unreachable in practice: validate_services/1 only admits modules that export
+        # __rpc_calls__/0, __message_props__/0, or descriptor/0, so a module reaching
+        # synthesize_descriptor/1 without any of those three is impossible.
+        raise "Module #{inspect(module)} exports neither descriptor/0, __rpc_calls__/0, nor __message_props__/0 — cannot synthesize a descriptor"
     end
   end
 end

--- a/lib/grpc_reflection/service/builder/extensions.ex
+++ b/lib/grpc_reflection/service/builder/extensions.ex
@@ -5,16 +5,20 @@ defmodule GrpcReflection.Service.Builder.Extensions do
   alias GrpcReflection.Service.State
 
   def add_extensions(state, symbol, module) do
-    extension_file = symbol <> "Extension.proto"
+    if not (Code.ensure_loaded?(module) and function_exported?(module, :descriptor, 0)) do
+      state
+    else
+      extension_file = symbol <> "Extension.proto"
 
-    case process_extensions(module, symbol, extension_file, module.descriptor()) do
-      {:ok, {extension_numbers, extension_payload}} ->
-        state
-        |> State.add_file(extension_payload)
-        |> State.add_extensions(%{symbol => extension_numbers})
+      case process_extensions(module, symbol, extension_file, module.descriptor()) do
+        {:ok, {extension_numbers, extension_payload}} ->
+          state
+          |> State.add_file(extension_payload)
+          |> State.add_extensions(%{symbol => extension_numbers})
 
-      :ignore ->
-        state
+        :ignore ->
+          state
+      end
     end
   end
 

--- a/lib/grpc_reflection/service/builder/extensions.ex
+++ b/lib/grpc_reflection/service/builder/extensions.ex
@@ -5,9 +5,7 @@ defmodule GrpcReflection.Service.Builder.Extensions do
   alias GrpcReflection.Service.State
 
   def add_extensions(state, symbol, module) do
-    if not (Code.ensure_loaded?(module) and function_exported?(module, :descriptor, 0)) do
-      state
-    else
+    if Code.ensure_loaded?(module) and function_exported?(module, :descriptor, 0) do
       extension_file = symbol <> "Extension.proto"
 
       case process_extensions(module, symbol, extension_file, module.descriptor()) do
@@ -19,6 +17,8 @@ defmodule GrpcReflection.Service.Builder.Extensions do
         :ignore ->
           state
       end
+    else
+      state
     end
   end
 

--- a/lib/grpc_reflection/service/builder/synthesizer.ex
+++ b/lib/grpc_reflection/service/builder/synthesizer.ex
@@ -121,10 +121,18 @@ defmodule GrpcReflection.Service.Builder.Synthesizer do
 
   # proto3 repeated scalars are implicitly packed — reflection clients infer this from
   # syntax, so options.packed must not be set (matches real protoc output).
-  defp field_options(%Protobuf.FieldProps{packed?: true}, :proto2),
-    do: %Google.Protobuf.FieldOptions{packed: true}
+  defp field_options(props, syntax) do
+    packed = props.packed? == true and syntax == :proto2
+    deprecated = props.deprecated? == true
 
-  defp field_options(_, _), do: nil
+    case {packed, deprecated} do
+      {false, false} ->
+        nil
+
+      {packed, deprecated} ->
+        %Google.Protobuf.FieldOptions{packed: packed || nil, deprecated: deprecated || nil}
+    end
+  end
 
   defp encode_default(nil), do: nil
   defp encode_default(v) when is_binary(v), do: v

--- a/lib/grpc_reflection/service/builder/synthesizer.ex
+++ b/lib/grpc_reflection/service/builder/synthesizer.ex
@@ -1,0 +1,155 @@
+defmodule GrpcReflection.Service.Builder.Synthesizer do
+  @moduledoc false
+
+  # Builds a FieldDescriptorProto from a Protobuf.FieldProps.
+  # Note: oneof_index is NOT set here for proto3_optional fields — those synthetic
+  # oneof indices are assigned in message_descriptor/1 where all fields are visible.
+  # syntax must be passed explicitly when building from message context; proto3 repeated
+  # scalars have packed?: true in FieldProps but must NOT set options.packed (implicit).
+  def field_descriptor_from_props(%Protobuf.FieldProps{} = props, syntax \\ :proto2) do
+    {type, type_name} = resolve_type(props)
+
+    %Google.Protobuf.FieldDescriptorProto{
+      name: props.name,
+      number: props.fnum,
+      json_name: props.json_name,
+      type: type,
+      type_name: type_name,
+      label: resolve_label(props),
+      default_value: encode_default(props.default),
+      oneof_index: props.oneof,
+      options: field_options(props, syntax),
+      proto3_optional: props.proto3_optional?,
+      extendee: nil
+    }
+  end
+
+  def message_descriptor(module) do
+    props = module.__message_props__()
+
+    fields =
+      props.ordered_tags
+      |> Enum.map(&props.field_props[&1])
+      |> Enum.map(&field_descriptor_from_props(&1, props.syntax))
+      |> assign_proto3_optional_oneof_indices(length(props.oneof))
+
+    real_oneof_decls =
+      Enum.map(props.oneof, fn {name, _tag} ->
+        %Google.Protobuf.OneofDescriptorProto{name: Atom.to_string(name)}
+      end)
+
+    synthetic_oneof_decls =
+      fields
+      |> Enum.filter(& &1.proto3_optional)
+      |> Enum.map(fn f ->
+        %Google.Protobuf.OneofDescriptorProto{name: "_#{f.name}"}
+      end)
+
+    extension_ranges =
+      (props.extension_range || [])
+      |> Enum.map(fn {start, stop} ->
+        %Google.Protobuf.DescriptorProto.ExtensionRange{start: start, end: stop}
+      end)
+
+    short_name = module.full_name() |> String.split(".") |> List.last()
+
+    %Google.Protobuf.DescriptorProto{
+      name: short_name,
+      field: fields,
+      oneof_decl: real_oneof_decls ++ synthetic_oneof_decls,
+      extension_range: extension_ranges,
+      nested_type: [],
+      enum_type: []
+    }
+  end
+
+  def enum_descriptor(module) do
+    short_name = module.full_name() |> String.split(".") |> List.last()
+
+    # mapping() is a map so has no intrinsic order; __message_props__.ordered_tags is
+    # numerically sorted. Neither preserves proto declaration order, so we sort by value.
+    # This differs from protoc output for enums with non-monotonic declaration order
+    # (e.g. negative sentinel values declared after positive ones), but reflection
+    # clients look up enum values by number, not position, so this is safe in practice.
+    values =
+      module.__message_props__().ordered_tags
+      |> Enum.map(fn tag ->
+        props = module.__message_props__().field_props[tag]
+        %Google.Protobuf.EnumValueDescriptorProto{name: props.name, number: props.fnum}
+      end)
+
+    %Google.Protobuf.EnumDescriptorProto{name: short_name, value: values}
+  end
+
+  def service_descriptor(module) do
+    service_name = module.__meta__(:name) |> String.split(".") |> List.last()
+
+    methods =
+      module.__rpc_calls__()
+      |> Enum.map(fn
+        {method, {req, req_stream}, {resp, resp_stream}} ->
+          build_method_descriptor(method, req, req_stream, resp, resp_stream)
+
+        {method, {req, req_stream}, {resp, resp_stream}, _opts} ->
+          build_method_descriptor(method, req, req_stream, resp, resp_stream)
+      end)
+
+    %Google.Protobuf.ServiceDescriptorProto{name: service_name, method: methods}
+  end
+
+  defp resolve_label(%Protobuf.FieldProps{required?: true}), do: :LABEL_REQUIRED
+  defp resolve_label(%Protobuf.FieldProps{repeated?: true}), do: :LABEL_REPEATED
+  defp resolve_label(%Protobuf.FieldProps{map?: true}), do: :LABEL_REPEATED
+  defp resolve_label(_), do: :LABEL_OPTIONAL
+
+  defp resolve_type(%Protobuf.FieldProps{enum?: true, type: {:enum, mod}}) do
+    {:TYPE_ENUM, "." <> mod.full_name()}
+  end
+
+  defp resolve_type(%Protobuf.FieldProps{embedded?: true, type: mod}) when is_atom(mod) do
+    {:TYPE_MESSAGE, "." <> mod.full_name()}
+  end
+
+  defp resolve_type(%Protobuf.FieldProps{type: type}) do
+    {:"TYPE_#{type |> Atom.to_string() |> String.upcase()}", nil}
+  end
+
+  # proto3 repeated scalars are implicitly packed — reflection clients infer this from
+  # syntax, so options.packed must not be set (matches real protoc output).
+  defp field_options(%Protobuf.FieldProps{packed?: true}, :proto2),
+    do: %Google.Protobuf.FieldOptions{packed: true}
+
+  defp field_options(_, _), do: nil
+
+  defp encode_default(nil), do: nil
+  defp encode_default(v) when is_binary(v), do: v
+  defp encode_default(v) when is_boolean(v), do: to_string(v)
+  defp encode_default(v) when is_integer(v), do: Integer.to_string(v)
+  defp encode_default(v) when is_float(v), do: Float.to_string(v)
+  defp encode_default(v) when is_atom(v), do: Atom.to_string(v)
+
+  # proto3_optional fields have no oneof in __message_props__ (the runtime doesn't need
+  # the synthetic oneof) but the wire format and reflection clients expect oneof_index to
+  # point at a synthetic "_fieldname" oneof entry appended after any real oneofs.
+  defp assign_proto3_optional_oneof_indices(fields, real_oneof_count) do
+    fields
+    |> Enum.map_reduce(0, fn field, counter ->
+      if field.proto3_optional do
+        {%{field | oneof_index: real_oneof_count + counter}, counter + 1}
+      else
+        {field, counter}
+      end
+    end)
+    |> elem(0)
+  end
+
+  defp build_method_descriptor(method, req, req_stream, resp, resp_stream) do
+    %Google.Protobuf.MethodDescriptorProto{
+      name: method |> Atom.to_string() |> Macro.camelize(),
+      input_type: "." <> req.full_name(),
+      output_type: "." <> resp.full_name(),
+      client_streaming: req_stream,
+      server_streaming: resp_stream
+    }
+  end
+end

--- a/lib/grpc_reflection/service/builder/synthesizer.ex
+++ b/lib/grpc_reflection/service/builder/synthesizer.ex
@@ -6,7 +6,7 @@ defmodule GrpcReflection.Service.Builder.Synthesizer do
   # oneof indices are assigned in message_descriptor/1 where all fields are visible.
   # syntax must be passed explicitly when building from message context; proto3 repeated
   # scalars have packed?: true in FieldProps but must NOT set options.packed (implicit).
-  def field_descriptor_from_props(%Protobuf.FieldProps{} = props, syntax \\ :proto2) do
+  def field_descriptor_from_props(%Protobuf.FieldProps{} = props, syntax \\ :proto3) do
     {type, type_name} = resolve_type(props)
 
     %Google.Protobuf.FieldDescriptorProto{
@@ -58,6 +58,11 @@ defmodule GrpcReflection.Service.Builder.Synthesizer do
       field: fields,
       oneof_decl: real_oneof_decls ++ synthetic_oneof_decls,
       extension_range: extension_ranges,
+      # nested_type is always [] in synthesized descriptors. All message types — including
+      # map-entry types and any inline nested message definitions in the original .proto —
+      # are discovered via field traversal in builder.ex and emitted as separate files.
+      # This differs from protoc output (which embeds nested types in the parent descriptor)
+      # but is handled correctly by standard reflection clients.
       nested_type: [],
       enum_type: []
     }
@@ -145,7 +150,7 @@ defmodule GrpcReflection.Service.Builder.Synthesizer do
 
   defp build_method_descriptor(method, req, req_stream, resp, resp_stream) do
     %Google.Protobuf.MethodDescriptorProto{
-      name: method |> Atom.to_string() |> Macro.camelize(),
+      name: Atom.to_string(method),
       input_type: "." <> req.full_name(),
       output_type: "." <> resp.full_name(),
       client_streaming: req_stream,

--- a/lib/grpc_reflection/service/builder/util.ex
+++ b/lib/grpc_reflection/service/builder/util.ex
@@ -108,6 +108,7 @@ defmodule GrpcReflection.Service.Builder.Util do
     invalid_services =
       Enum.reject(services, fn service_mod ->
         Code.ensure_loaded?(service_mod) and
+          function_exported?(service_mod, :__meta__, 1) and
           is_binary(service_mod.__meta__(:name)) and
           (function_exported?(service_mod, :descriptor, 0) or
              function_exported?(service_mod, :__rpc_calls__, 0))

--- a/lib/grpc_reflection/service/builder/util.ex
+++ b/lib/grpc_reflection/service/builder/util.ex
@@ -107,8 +107,10 @@ defmodule GrpcReflection.Service.Builder.Util do
   def validate_services(services) do
     invalid_services =
       Enum.reject(services, fn service_mod ->
-        is_binary(service_mod.__meta__(:name)) and
-          is_struct(service_mod.descriptor())
+        Code.ensure_loaded?(service_mod) and
+          is_binary(service_mod.__meta__(:name)) and
+          (function_exported?(service_mod, :descriptor, 0) or
+             function_exported?(service_mod, :__rpc_calls__, 0))
       end)
 
     case invalid_services do

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule GrpcReflection.MixProject do
           ~r/^PackageB\./,
           ~r/^NestedEnumConflict\./,
           ~r/^RecursiveMessage\./,
+          ~r/^NoDescriptor\./,
           GrpcReflection.TestEndpoint,
           GrpcReflection.TestEndpoint.Endpoint
         ]
@@ -74,16 +75,13 @@ defmodule GrpcReflection.MixProject do
     ]
   end
 
-  defp build_protos(_argv) do
-    options =
-      Enum.join(
-        [
-          "gen_descriptors=true",
-          "plugins=grpc"
-        ],
-        ","
-      )
+  @protoc_opts "gen_descriptors=true,plugins=grpc"
+  @protoc_opts_no_descriptor "package_prefix=NoDescriptor,plugins=grpc"
+  # Protos with a file-level (elixirpb.file).module_prefix override package_prefix,
+  # so the no-descriptor pass would produce duplicate module names.
+  @skip_no_descriptor ["custom_prefix_service.proto"]
 
+  defp build_protos(_argv) do
     # compile reflection protos
     Enum.each(
       [
@@ -92,19 +90,25 @@ defmodule GrpcReflection.MixProject do
       ],
       fn reflection_proto ->
         Mix.shell().cmd(
-          "protoc --elixir_out=#{options}:./lib/proto --proto_path=priv/protos/ #{reflection_proto}"
+          "protoc --elixir_out=#{@protoc_opts}:./lib/proto --proto_path=priv/protos/ #{reflection_proto}"
         )
       end
     )
 
-    # compile test protos
+    # compile test protos — once with descriptors, once without
     "./priv/protos"
     |> File.ls!()
     |> Enum.filter(&Regex.match?(~r/.*.proto$/, &1))
-    |> Enum.each(fn reflection_proto ->
+    |> Enum.each(fn proto ->
       Mix.shell().cmd(
-        "protoc --elixir_out=#{options}:./test/support/protos -I priv/protos/ -I deps/protobuf/src #{reflection_proto}"
+        "protoc --elixir_out=#{@protoc_opts}:./test/support/protos -I priv/protos/ -I deps/protobuf/src #{proto}"
       )
+
+      unless proto in @skip_no_descriptor do
+        Mix.shell().cmd(
+          "protoc --elixir_out=#{@protoc_opts_no_descriptor}:./test/support/protos/no_descriptor -I priv/protos/ -I deps/protobuf/src #{proto}"
+        )
+      end
     end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -77,8 +77,10 @@ defmodule GrpcReflection.MixProject do
 
   @protoc_opts "gen_descriptors=true,plugins=grpc"
   @protoc_opts_no_descriptor "package_prefix=NoDescriptor,plugins=grpc"
-  # Protos with a file-level (elixirpb.file).module_prefix override package_prefix,
-  # so the no-descriptor pass would produce duplicate module names.
+  # Protos that set (elixirpb.file).module_prefix must be skipped here: that option
+  # overrides package_prefix entirely, so the no-descriptor pass would emit modules with
+  # the same name as the descriptor pass, causing a compile-time conflict.
+  # Add any proto that uses the elixirpb.file module_prefix option to this list.
   @skip_no_descriptor ["custom_prefix_service.proto"]
 
   defp build_protos(_argv) do

--- a/priv/protos/deprecated_fields.proto
+++ b/priv/protos/deprecated_fields.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package deprecated_fields;
+
+option go_package = "deprecated_fields";
+
+// A message with a mix of active and deprecated fields.
+message DeprecatedRequest {
+  string active_field = 1;
+  string legacy_field = 2 [deprecated = true];
+  int32  active_id    = 3;
+  int32  old_id       = 4 [deprecated = true];
+}
+
+message DeprecatedResponse {
+  bool   success      = 1;
+  string result       = 2;
+  string old_result   = 3 [deprecated = true];
+}
+
+service DeprecatedFieldsService {
+  rpc Process(DeprecatedRequest) returns (DeprecatedResponse);
+}

--- a/priv/protos/proto2_features.proto
+++ b/priv/protos/proto2_features.proto
@@ -37,6 +37,9 @@ message Proto2Request {
   // Repeated Any in proto2
   repeated google.protobuf.Any any_values = 15;
 
+  // Packed repeated field (proto2 requires explicit [packed=true])
+  repeated int32 packed_ints = 16 [packed=true];
+
   // Extensions range
   extensions 100 to 199;
 }

--- a/test/case/no_descriptor/deprecated_fields_test.exs
+++ b/test/case/no_descriptor/deprecated_fields_test.exs
@@ -1,0 +1,68 @@
+defmodule GrpcReflection.Case.NoDescriptor.DeprecatedFieldsTest do
+  @moduledoc false
+
+  use GrpcCase, service: NoDescriptor.DeprecatedFields.DeprecatedFieldsService.Service
+
+  versions = ["v1", "v1alpha"]
+
+  for version <- versions do
+    describe version do
+      setup String.to_existing_atom("stub_#{version}_server")
+
+      test "should list services", ctx do
+        message = {:list_services, ""}
+        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+
+        assert Enum.map(service_list, &Map.get(&1, :name)) == [
+                 "deprecated_fields.DeprecatedFieldsService"
+               ]
+      end
+
+      test "deprecated fields carry options.deprecated true, active fields do not", ctx do
+        message = {:file_containing_symbol, "deprecated_fields.DeprecatedRequest"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "deprecated_fields",
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{name: "DeprecatedRequest", field: fields}
+                 ]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+
+        assert %{options: nil} = by_name["active_field"]
+        assert %{options: nil} = by_name["active_id"]
+
+        assert %{options: %Google.Protobuf.FieldOptions{deprecated: true}} =
+                 by_name["legacy_field"]
+
+        assert %{options: %Google.Protobuf.FieldOptions{deprecated: true}} = by_name["old_id"]
+      end
+
+      test "deprecated field on response also carries options.deprecated true", ctx do
+        message = {:file_containing_symbol, "deprecated_fields.DeprecatedResponse"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{name: "DeprecatedResponse", field: fields}
+                 ]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+
+        assert %{options: nil} = by_name["success"]
+        assert %{options: nil} = by_name["result"]
+        assert %{options: %Google.Protobuf.FieldOptions{deprecated: true}} = by_name["old_result"]
+      end
+
+      test "reflection graph is traversable using grpcurl", ctx do
+        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
+
+        assert {:call, "deprecated_fields.DeprecatedFieldsService.Process"} in ops
+        assert {:service, "deprecated_fields.DeprecatedFieldsService"} in ops
+      end
+    end
+  end
+end

--- a/test/case/no_descriptor/deprecated_fields_test.exs
+++ b/test/case/no_descriptor/deprecated_fields_test.exs
@@ -3,66 +3,60 @@ defmodule GrpcReflection.Case.NoDescriptor.DeprecatedFieldsTest do
 
   use GrpcCase, service: NoDescriptor.DeprecatedFields.DeprecatedFieldsService.Service
 
-  versions = ["v1", "v1alpha"]
+  setup :stub_v1_server
 
-  for version <- versions do
-    describe version do
-      setup String.to_existing_atom("stub_#{version}_server")
+  test "should list services", ctx do
+    message = {:list_services, ""}
+    assert {:ok, %{service: service_list}} = run_request(message, ctx)
 
-      test "should list services", ctx do
-        message = {:list_services, ""}
-        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+    assert Enum.map(service_list, &Map.get(&1, :name)) == [
+             "deprecated_fields.DeprecatedFieldsService"
+           ]
+  end
 
-        assert Enum.map(service_list, &Map.get(&1, :name)) == [
-                 "deprecated_fields.DeprecatedFieldsService"
-               ]
-      end
+  test "deprecated fields carry options.deprecated true, active fields do not", ctx do
+    message = {:file_containing_symbol, "deprecated_fields.DeprecatedRequest"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "deprecated fields carry options.deprecated true, active fields do not", ctx do
-        message = {:file_containing_symbol, "deprecated_fields.DeprecatedRequest"}
-        assert {:ok, response} = run_request(message, ctx)
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "deprecated_fields",
+             message_type: [
+               %Google.Protobuf.DescriptorProto{name: "DeprecatedRequest", field: fields}
+             ]
+           } = response
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "deprecated_fields",
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{name: "DeprecatedRequest", field: fields}
-                 ]
-               } = response
+    by_name = Map.new(fields, &{&1.name, &1})
 
-        by_name = Map.new(fields, &{&1.name, &1})
+    assert %{options: nil} = by_name["active_field"]
+    assert %{options: nil} = by_name["active_id"]
 
-        assert %{options: nil} = by_name["active_field"]
-        assert %{options: nil} = by_name["active_id"]
+    assert %{options: %Google.Protobuf.FieldOptions{deprecated: true}} =
+             by_name["legacy_field"]
 
-        assert %{options: %Google.Protobuf.FieldOptions{deprecated: true}} =
-                 by_name["legacy_field"]
+    assert %{options: %Google.Protobuf.FieldOptions{deprecated: true}} = by_name["old_id"]
+  end
 
-        assert %{options: %Google.Protobuf.FieldOptions{deprecated: true}} = by_name["old_id"]
-      end
+  test "deprecated field on response also carries options.deprecated true", ctx do
+    message = {:file_containing_symbol, "deprecated_fields.DeprecatedResponse"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "deprecated field on response also carries options.deprecated true", ctx do
-        message = {:file_containing_symbol, "deprecated_fields.DeprecatedResponse"}
-        assert {:ok, response} = run_request(message, ctx)
+    assert %Google.Protobuf.FileDescriptorProto{
+             message_type: [
+               %Google.Protobuf.DescriptorProto{name: "DeprecatedResponse", field: fields}
+             ]
+           } = response
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{name: "DeprecatedResponse", field: fields}
-                 ]
-               } = response
+    by_name = Map.new(fields, &{&1.name, &1})
 
-        by_name = Map.new(fields, &{&1.name, &1})
+    assert %{options: nil} = by_name["success"]
+    assert %{options: nil} = by_name["result"]
+    assert %{options: %Google.Protobuf.FieldOptions{deprecated: true}} = by_name["old_result"]
+  end
 
-        assert %{options: nil} = by_name["success"]
-        assert %{options: nil} = by_name["result"]
-        assert %{options: %Google.Protobuf.FieldOptions{deprecated: true}} = by_name["old_result"]
-      end
+  test "reflection graph is traversable using grpcurl", ctx do
+    ops = GrpcReflection.TestClient.grpcurl_service(ctx)
 
-      test "reflection graph is traversable using grpcurl", ctx do
-        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
-
-        assert {:call, "deprecated_fields.DeprecatedFieldsService.Process"} in ops
-        assert {:service, "deprecated_fields.DeprecatedFieldsService"} in ops
-      end
-    end
+    assert {:call, "deprecated_fields.DeprecatedFieldsService.Process"} in ops
+    assert {:service, "deprecated_fields.DeprecatedFieldsService"} in ops
   end
 end

--- a/test/case/no_descriptor/edge_cases_test.exs
+++ b/test/case/no_descriptor/edge_cases_test.exs
@@ -1,0 +1,60 @@
+defmodule GrpcReflection.Case.NoDescriptor.EdgeCasesTest do
+  @moduledoc false
+
+  use GrpcCase, service: NoDescriptor.EdgeCases.EdgeCaseService.Service
+
+  versions = ["v1", "v1alpha"]
+
+  for version <- versions do
+    describe version do
+      setup String.to_existing_atom("stub_#{version}_server")
+
+      test "should list services", ctx do
+        message = {:list_services, ""}
+        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+        assert Enum.map(service_list, &Map.get(&1, :name)) == ["edge_cases.EdgeCaseService"]
+      end
+
+      test "should list methods on our service", ctx do
+        message = {:file_containing_symbol, "edge_cases.EdgeCaseService"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "edge_cases",
+                 service: [
+                   %Google.Protobuf.ServiceDescriptorProto{
+                     name: "EdgeCaseService",
+                     method: methods
+                   }
+                 ]
+               } = response
+
+        by_name = Map.new(methods, &{&1.name, &1})
+        assert %{input_type: ".edge_cases.EmptyInputRequest"} = by_name["EmptyInput"]
+        assert %{output_type: ".edge_cases.EmptyOutputResponse"} = by_name["EmptyOutput"]
+        assert %{input_type: ".edge_cases.BothEmptyRequest"} = by_name["BothEmpty"]
+      end
+
+      test "empty message has no fields", ctx do
+        message = {:file_containing_symbol, "edge_cases.BothEmptyRequest"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "edge_cases",
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{name: "BothEmptyRequest", field: []}
+                 ]
+               } = response
+      end
+
+      test "reflection graph is traversable using grpcurl", ctx do
+        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
+
+        assert {:call, "edge_cases.EdgeCaseService.BothEmpty"} in ops
+        assert {:call, "edge_cases.EdgeCaseService.EmptyInput"} in ops
+        assert {:call, "edge_cases.EdgeCaseService.EmptyOutput"} in ops
+        assert {:service, "edge_cases.EdgeCaseService"} in ops
+      end
+    end
+  end
+end

--- a/test/case/no_descriptor/edge_cases_test.exs
+++ b/test/case/no_descriptor/edge_cases_test.exs
@@ -3,58 +3,52 @@ defmodule GrpcReflection.Case.NoDescriptor.EdgeCasesTest do
 
   use GrpcCase, service: NoDescriptor.EdgeCases.EdgeCaseService.Service
 
-  versions = ["v1", "v1alpha"]
+  setup :stub_v1_server
 
-  for version <- versions do
-    describe version do
-      setup String.to_existing_atom("stub_#{version}_server")
+  test "should list services", ctx do
+    message = {:list_services, ""}
+    assert {:ok, %{service: service_list}} = run_request(message, ctx)
+    assert Enum.map(service_list, &Map.get(&1, :name)) == ["edge_cases.EdgeCaseService"]
+  end
 
-      test "should list services", ctx do
-        message = {:list_services, ""}
-        assert {:ok, %{service: service_list}} = run_request(message, ctx)
-        assert Enum.map(service_list, &Map.get(&1, :name)) == ["edge_cases.EdgeCaseService"]
-      end
+  test "should list methods on our service", ctx do
+    message = {:file_containing_symbol, "edge_cases.EdgeCaseService"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "should list methods on our service", ctx do
-        message = {:file_containing_symbol, "edge_cases.EdgeCaseService"}
-        assert {:ok, response} = run_request(message, ctx)
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "edge_cases",
+             service: [
+               %Google.Protobuf.ServiceDescriptorProto{
+                 name: "EdgeCaseService",
+                 method: methods
+               }
+             ]
+           } = response
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "edge_cases",
-                 service: [
-                   %Google.Protobuf.ServiceDescriptorProto{
-                     name: "EdgeCaseService",
-                     method: methods
-                   }
-                 ]
-               } = response
+    by_name = Map.new(methods, &{&1.name, &1})
+    assert %{input_type: ".edge_cases.EmptyInputRequest"} = by_name["EmptyInput"]
+    assert %{output_type: ".edge_cases.EmptyOutputResponse"} = by_name["EmptyOutput"]
+    assert %{input_type: ".edge_cases.BothEmptyRequest"} = by_name["BothEmpty"]
+  end
 
-        by_name = Map.new(methods, &{&1.name, &1})
-        assert %{input_type: ".edge_cases.EmptyInputRequest"} = by_name["EmptyInput"]
-        assert %{output_type: ".edge_cases.EmptyOutputResponse"} = by_name["EmptyOutput"]
-        assert %{input_type: ".edge_cases.BothEmptyRequest"} = by_name["BothEmpty"]
-      end
+  test "empty message has no fields", ctx do
+    message = {:file_containing_symbol, "edge_cases.BothEmptyRequest"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "empty message has no fields", ctx do
-        message = {:file_containing_symbol, "edge_cases.BothEmptyRequest"}
-        assert {:ok, response} = run_request(message, ctx)
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "edge_cases",
+             message_type: [
+               %Google.Protobuf.DescriptorProto{name: "BothEmptyRequest", field: []}
+             ]
+           } = response
+  end
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "edge_cases",
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{name: "BothEmptyRequest", field: []}
-                 ]
-               } = response
-      end
+  test "reflection graph is traversable using grpcurl", ctx do
+    ops = GrpcReflection.TestClient.grpcurl_service(ctx)
 
-      test "reflection graph is traversable using grpcurl", ctx do
-        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
-
-        assert {:call, "edge_cases.EdgeCaseService.BothEmpty"} in ops
-        assert {:call, "edge_cases.EdgeCaseService.EmptyInput"} in ops
-        assert {:call, "edge_cases.EdgeCaseService.EmptyOutput"} in ops
-        assert {:service, "edge_cases.EdgeCaseService"} in ops
-      end
-    end
+    assert {:call, "edge_cases.EdgeCaseService.BothEmpty"} in ops
+    assert {:call, "edge_cases.EdgeCaseService.EmptyInput"} in ops
+    assert {:call, "edge_cases.EdgeCaseService.EmptyOutput"} in ops
+    assert {:service, "edge_cases.EdgeCaseService"} in ops
   end
 end

--- a/test/case/no_descriptor/imports_test_test.exs
+++ b/test/case/no_descriptor/imports_test_test.exs
@@ -3,89 +3,83 @@ defmodule GrpcReflection.Case.NoDescriptor.ImportsTestServiceTest do
 
   use GrpcCase, service: NoDescriptor.ImportsTest.ImportTestService.Service
 
-  versions = ["v1", "v1alpha"]
+  setup :stub_v1_server
 
-  for version <- versions do
-    describe version do
-      setup String.to_existing_atom("stub_#{version}_server")
+  test "should list services", ctx do
+    message = {:list_services, ""}
+    assert {:ok, %{service: service_list}} = run_request(message, ctx)
+    assert Enum.map(service_list, &Map.get(&1, :name)) == ["imports_test.ImportTestService"]
+  end
 
-      test "should list services", ctx do
-        message = {:list_services, ""}
-        assert {:ok, %{service: service_list}} = run_request(message, ctx)
-        assert Enum.map(service_list, &Map.get(&1, :name)) == ["imports_test.ImportTestService"]
-      end
+  test "should list methods on our service", ctx do
+    message = {:file_containing_symbol, "imports_test.ImportTestService"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "should list methods on our service", ctx do
-        message = {:file_containing_symbol, "imports_test.ImportTestService"}
-        assert {:ok, response} = run_request(message, ctx)
-
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "imports_test",
-                 service: [
-                   %Google.Protobuf.ServiceDescriptorProto{
-                     name: "ImportTestService",
-                     method: [
-                       %Google.Protobuf.MethodDescriptorProto{
-                         name: "CreateUser",
-                         input_type: ".imports_test.UserRequest",
-                         output_type: ".imports_test.UserResponse"
-                       },
-                       %Google.Protobuf.MethodDescriptorProto{
-                         name: "UpdateLocation",
-                         input_type: ".imports_test.LocationUpdate",
-                         output_type: ".imports_test.LocationResponse"
-                       }
-                     ]
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "imports_test",
+             service: [
+               %Google.Protobuf.ServiceDescriptorProto{
+                 name: "ImportTestService",
+                 method: [
+                   %Google.Protobuf.MethodDescriptorProto{
+                     name: "CreateUser",
+                     input_type: ".imports_test.UserRequest",
+                     output_type: ".imports_test.UserResponse"
+                   },
+                   %Google.Protobuf.MethodDescriptorProto{
+                     name: "UpdateLocation",
+                     input_type: ".imports_test.LocationUpdate",
+                     output_type: ".imports_test.LocationResponse"
                    }
                  ]
-               } = response
-      end
+               }
+             ]
+           } = response
+  end
 
-      test "cross-package type common.Address is resolvable by symbol", ctx do
-        message = {:file_containing_symbol, "common.Address"}
-        assert {:ok, response} = run_request(message, ctx)
+  test "cross-package type common.Address is resolvable by symbol", ctx do
+    message = {:file_containing_symbol, "common.Address"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "common",
-                 message_type: [%Google.Protobuf.DescriptorProto{name: "Address", field: fields}]
-               } = response
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "common",
+             message_type: [%Google.Protobuf.DescriptorProto{name: "Address", field: fields}]
+           } = response
 
-        by_name = Map.new(fields, &{&1.name, &1})
-        assert %{type: :TYPE_STRING, number: 1} = by_name["street"]
-        assert %{type: :TYPE_STRING, number: 5} = by_name["country"]
-      end
+    by_name = Map.new(fields, &{&1.name, &1})
+    assert %{type: :TYPE_STRING, number: 1} = by_name["street"]
+    assert %{type: :TYPE_STRING, number: 5} = by_name["country"]
+  end
 
-      test "google.protobuf.Timestamp is resolvable by symbol", ctx do
-        message = {:file_containing_symbol, "google.protobuf.Timestamp"}
-        assert {:ok, response} = run_request(message, ctx)
+  test "google.protobuf.Timestamp is resolvable by symbol", ctx do
+    message = {:file_containing_symbol, "google.protobuf.Timestamp"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "google.protobuf",
-                 message_type: [%Google.Protobuf.DescriptorProto{name: "Timestamp"}]
-               } = response
-      end
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "google.protobuf",
+             message_type: [%Google.Protobuf.DescriptorProto{name: "Timestamp"}]
+           } = response
+  end
 
-      test "UserRequest lists cross-package dependencies", ctx do
-        message = {:file_by_filename, "imports_test.UserRequest.proto"}
-        assert {:ok, response} = run_request(message, ctx)
+  test "UserRequest lists cross-package dependencies", ctx do
+    message = {:file_by_filename, "imports_test.UserRequest.proto"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 name: "imports_test.UserRequest.proto",
-                 package: "imports_test"
-               } = response
+    assert %Google.Protobuf.FileDescriptorProto{
+             name: "imports_test.UserRequest.proto",
+             package: "imports_test"
+           } = response
 
-        assert "common.Address.proto" in response.dependency
-        assert "common.Coordinates.proto" in response.dependency
-        assert "google.protobuf.Timestamp.proto" in response.dependency
-      end
+    assert "common.Address.proto" in response.dependency
+    assert "common.Coordinates.proto" in response.dependency
+    assert "google.protobuf.Timestamp.proto" in response.dependency
+  end
 
-      @tag :skip
-      test "reflection graph is traversable using grpcurl", _ctx do
-        # LocationResponse has a map field (VisitHistoryEntry). Without descriptor/0 the
-        # synthesized descriptor has nested_type: [], so VisitHistoryEntry is emitted as a
-        # standalone file. grpcurl cannot resolve the cross-reference and returns exit code 1.
-        # This is the same known synthesizer limitation as proto2_features (map-entry types).
-      end
-    end
+  @tag :skip
+  test "reflection graph is traversable using grpcurl", _ctx do
+    # LocationResponse has a map field (VisitHistoryEntry). Without descriptor/0 the
+    # synthesized descriptor has nested_type: [], so VisitHistoryEntry is emitted as a
+    # standalone file. grpcurl cannot resolve the cross-reference and returns exit code 1.
+    # This is the same known synthesizer limitation as proto2_features (map-entry types).
   end
 end

--- a/test/case/no_descriptor/imports_test_test.exs
+++ b/test/case/no_descriptor/imports_test_test.exs
@@ -1,0 +1,91 @@
+defmodule GrpcReflection.Case.NoDescriptor.ImportsTestServiceTest do
+  @moduledoc false
+
+  use GrpcCase, service: NoDescriptor.ImportsTest.ImportTestService.Service
+
+  versions = ["v1", "v1alpha"]
+
+  for version <- versions do
+    describe version do
+      setup String.to_existing_atom("stub_#{version}_server")
+
+      test "should list services", ctx do
+        message = {:list_services, ""}
+        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+        assert Enum.map(service_list, &Map.get(&1, :name)) == ["imports_test.ImportTestService"]
+      end
+
+      test "should list methods on our service", ctx do
+        message = {:file_containing_symbol, "imports_test.ImportTestService"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "imports_test",
+                 service: [
+                   %Google.Protobuf.ServiceDescriptorProto{
+                     name: "ImportTestService",
+                     method: [
+                       %Google.Protobuf.MethodDescriptorProto{
+                         name: "CreateUser",
+                         input_type: ".imports_test.UserRequest",
+                         output_type: ".imports_test.UserResponse"
+                       },
+                       %Google.Protobuf.MethodDescriptorProto{
+                         name: "UpdateLocation",
+                         input_type: ".imports_test.LocationUpdate",
+                         output_type: ".imports_test.LocationResponse"
+                       }
+                     ]
+                   }
+                 ]
+               } = response
+      end
+
+      test "cross-package type common.Address is resolvable by symbol", ctx do
+        message = {:file_containing_symbol, "common.Address"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "common",
+                 message_type: [%Google.Protobuf.DescriptorProto{name: "Address", field: fields}]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+        assert %{type: :TYPE_STRING, number: 1} = by_name["street"]
+        assert %{type: :TYPE_STRING, number: 5} = by_name["country"]
+      end
+
+      test "google.protobuf.Timestamp is resolvable by symbol", ctx do
+        message = {:file_containing_symbol, "google.protobuf.Timestamp"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "google.protobuf",
+                 message_type: [%Google.Protobuf.DescriptorProto{name: "Timestamp"}]
+               } = response
+      end
+
+      test "UserRequest lists cross-package dependencies", ctx do
+        message = {:file_by_filename, "imports_test.UserRequest.proto"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 name: "imports_test.UserRequest.proto",
+                 package: "imports_test"
+               } = response
+
+        assert "common.Address.proto" in response.dependency
+        assert "common.Coordinates.proto" in response.dependency
+        assert "google.protobuf.Timestamp.proto" in response.dependency
+      end
+
+      @tag :skip
+      test "reflection graph is traversable using grpcurl", _ctx do
+        # LocationResponse has a map field (VisitHistoryEntry). Without descriptor/0 the
+        # synthesized descriptor has nested_type: [], so VisitHistoryEntry is emitted as a
+        # standalone file. grpcurl cannot resolve the cross-reference and returns exit code 1.
+        # This is the same known synthesizer limitation as proto2_features (map-entry types).
+      end
+    end
+  end
+end

--- a/test/case/no_descriptor/proto2_features_test.exs
+++ b/test/case/no_descriptor/proto2_features_test.exs
@@ -3,124 +3,113 @@ defmodule GrpcReflection.Case.NoDescriptor.Proto2FeaturesTest do
 
   use GrpcCase, service: NoDescriptor.Proto2Features.Proto2Service.Service
 
-  versions = ["v1", "v1alpha"]
+  setup :stub_v1_server
 
-  for version <- versions do
-    describe version do
-      setup String.to_existing_atom("stub_#{version}_server")
+  test "should list services", ctx do
+    message = {:list_services, ""}
+    assert {:ok, %{service: service_list}} = run_request(message, ctx)
+    assert Enum.map(service_list, &Map.get(&1, :name)) == ["proto2_features.Proto2Service"]
+  end
 
-      test "should list services", ctx do
-        message = {:list_services, ""}
-        assert {:ok, %{service: service_list}} = run_request(message, ctx)
-        assert Enum.map(service_list, &Map.get(&1, :name)) == ["proto2_features.Proto2Service"]
-      end
+  test "should list methods on our service", ctx do
+    message = {:file_containing_symbol, "proto2_features.Proto2Service"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "should list methods on our service", ctx do
-        message = {:file_containing_symbol, "proto2_features.Proto2Service"}
-        assert {:ok, response} = run_request(message, ctx)
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "proto2_features"
+           } = response
+  end
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "proto2_features"
-               } = response
-      end
+  test "proto2 required fields have LABEL_REQUIRED", ctx do
+    message = {:file_containing_symbol, "proto2_features.Proto2Request"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "proto2 required fields have LABEL_REQUIRED", ctx do
-        message = {:file_containing_symbol, "proto2_features.Proto2Request"}
-        assert {:ok, response} = run_request(message, ctx)
+    assert %Google.Protobuf.FileDescriptorProto{
+             message_type: [
+               %Google.Protobuf.DescriptorProto{name: "Proto2Request", field: fields}
+             ]
+           } = response
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{name: "Proto2Request", field: fields}
-                 ]
-               } = response
+    by_name = Map.new(fields, &{&1.name, &1})
 
-        by_name = Map.new(fields, &{&1.name, &1})
+    assert %{label: :LABEL_REQUIRED, type: :TYPE_STRING, number: 1} = by_name["required_field"]
+    assert %{label: :LABEL_REQUIRED, type: :TYPE_INT32, number: 2} = by_name["required_id"]
+    assert %{label: :LABEL_OPTIONAL, type: :TYPE_STRING, number: 3} = by_name["optional_field"]
+    assert %{label: :LABEL_OPTIONAL, type: :TYPE_INT32, number: 4} = by_name["optional_id"]
+  end
 
-        assert %{label: :LABEL_REQUIRED, type: :TYPE_STRING, number: 1} =
-                 by_name["required_field"]
+  test "proto2 default values are reflected", ctx do
+    message = {:file_containing_symbol, "proto2_features.Proto2Request"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %{label: :LABEL_REQUIRED, type: :TYPE_INT32, number: 2} = by_name["required_id"]
+    assert %Google.Protobuf.FileDescriptorProto{
+             message_type: [
+               %Google.Protobuf.DescriptorProto{field: fields}
+             ]
+           } = response
 
-        assert %{label: :LABEL_OPTIONAL, type: :TYPE_STRING, number: 3} =
-                 by_name["optional_field"]
+    by_name = Map.new(fields, &{&1.name, &1})
+    assert %{label: :LABEL_OPTIONAL, default_value: "unknown"} = by_name["name"]
+    assert %{label: :LABEL_OPTIONAL, default_value: "8080"} = by_name["port"]
+    assert %{label: :LABEL_OPTIONAL, default_value: "true"} = by_name["enabled"]
+    assert %{type: :TYPE_ENUM, default_value: "ACTIVE"} = by_name["status"]
+  end
 
-        assert %{label: :LABEL_OPTIONAL, type: :TYPE_INT32, number: 4} = by_name["optional_id"]
-      end
+  test "proto2 oneof fields carry oneof_index", ctx do
+    message = {:file_containing_symbol, "proto2_features.Proto2Request"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "proto2 default values are reflected", ctx do
-        message = {:file_containing_symbol, "proto2_features.Proto2Request"}
-        assert {:ok, response} = run_request(message, ctx)
+    assert %Google.Protobuf.FileDescriptorProto{
+             message_type: [
+               %Google.Protobuf.DescriptorProto{
+                 field: fields,
+                 oneof_decl: [%Google.Protobuf.OneofDescriptorProto{name: "proto2_oneof"}]
+               }
+             ]
+           } = response
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{field: fields}
-                 ]
-               } = response
+    by_name = Map.new(fields, &{&1.name, &1})
+    assert %{oneof_index: 0} = by_name["oneof_string"]
+    assert %{oneof_index: 0} = by_name["oneof_int"]
+  end
 
-        by_name = Map.new(fields, &{&1.name, &1})
-        assert %{label: :LABEL_OPTIONAL, default_value: "unknown"} = by_name["name"]
-        assert %{label: :LABEL_OPTIONAL, default_value: "8080"} = by_name["port"]
-        assert %{label: :LABEL_OPTIONAL, default_value: "true"} = by_name["enabled"]
-        assert %{type: :TYPE_ENUM, default_value: "ACTIVE"} = by_name["status"]
-      end
+  test "proto2 packed repeated field has options.packed", ctx do
+    message = {:file_containing_symbol, "proto2_features.Proto2Request"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "proto2 oneof fields carry oneof_index", ctx do
-        message = {:file_containing_symbol, "proto2_features.Proto2Request"}
-        assert {:ok, response} = run_request(message, ctx)
+    assert %Google.Protobuf.FileDescriptorProto{
+             message_type: [%Google.Protobuf.DescriptorProto{field: fields}]
+           } = response
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{
-                     field: fields,
-                     oneof_decl: [%Google.Protobuf.OneofDescriptorProto{name: "proto2_oneof"}]
-                   }
-                 ]
-               } = response
+    by_name = Map.new(fields, &{&1.name, &1})
 
-        by_name = Map.new(fields, &{&1.name, &1})
-        assert %{oneof_index: 0} = by_name["oneof_string"]
-        assert %{oneof_index: 0} = by_name["oneof_int"]
-      end
+    assert %{
+             label: :LABEL_REPEATED,
+             type: :TYPE_INT32,
+             options: %Google.Protobuf.FieldOptions{packed: true}
+           } = by_name["packed_ints"]
+  end
 
-      test "proto2 packed repeated field has options.packed", ctx do
-        message = {:file_containing_symbol, "proto2_features.Proto2Request"}
-        assert {:ok, response} = run_request(message, ctx)
+  test "proto2 response required fields have LABEL_REQUIRED", ctx do
+    message = {:file_containing_symbol, "proto2_features.Proto2Response"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 message_type: [%Google.Protobuf.DescriptorProto{field: fields}]
-               } = response
+    assert %Google.Protobuf.FileDescriptorProto{
+             message_type: [
+               %Google.Protobuf.DescriptorProto{name: "Proto2Response", field: fields}
+             ]
+           } = response
 
-        by_name = Map.new(fields, &{&1.name, &1})
+    by_name = Map.new(fields, &{&1.name, &1})
+    assert %{label: :LABEL_REQUIRED, type: :TYPE_BOOL, number: 1} = by_name["success"]
+    assert %{label: :LABEL_OPTIONAL, type: :TYPE_STRING, number: 2} = by_name["message"]
+  end
 
-        assert %{
-                 label: :LABEL_REPEATED,
-                 type: :TYPE_INT32,
-                 options: %Google.Protobuf.FieldOptions{packed: true}
-               } = by_name["packed_ints"]
-      end
-
-      test "proto2 response required fields have LABEL_REQUIRED", ctx do
-        message = {:file_containing_symbol, "proto2_features.Proto2Response"}
-        assert {:ok, response} = run_request(message, ctx)
-
-        assert %Google.Protobuf.FileDescriptorProto{
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{name: "Proto2Response", field: fields}
-                 ]
-               } = response
-
-        by_name = Map.new(fields, &{&1.name, &1})
-        assert %{label: :LABEL_REQUIRED, type: :TYPE_BOOL, number: 1} = by_name["success"]
-        assert %{label: :LABEL_OPTIONAL, type: :TYPE_STRING, number: 2} = by_name["message"]
-      end
-
-      @tag :skip
-      test "reflection graph is traversable using grpcurl", _ctx do
-        # MetadataMapEntry is a map-entry nested type. Without descriptor/0 the synthesized
-        # Proto2Request has nested_type: [] so MetadataMapEntry is emitted as a standalone
-        # file. grpcurl cannot resolve the cross-reference and returns exit code 1.
-        # This is a known synthesizer limitation for map fields with nested entry types.
-      end
-    end
+  @tag :skip
+  test "reflection graph is traversable using grpcurl", _ctx do
+    # MetadataMapEntry is a map-entry nested type. Without descriptor/0 the synthesized
+    # Proto2Request has nested_type: [] so MetadataMapEntry is emitted as a standalone
+    # file. grpcurl cannot resolve the cross-reference and returns exit code 1.
+    # This is a known synthesizer limitation for map fields with nested entry types.
   end
 end

--- a/test/case/no_descriptor/proto2_features_test.exs
+++ b/test/case/no_descriptor/proto2_features_test.exs
@@ -1,0 +1,126 @@
+defmodule GrpcReflection.Case.NoDescriptor.Proto2FeaturesTest do
+  @moduledoc false
+
+  use GrpcCase, service: NoDescriptor.Proto2Features.Proto2Service.Service
+
+  versions = ["v1", "v1alpha"]
+
+  for version <- versions do
+    describe version do
+      setup String.to_existing_atom("stub_#{version}_server")
+
+      test "should list services", ctx do
+        message = {:list_services, ""}
+        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+        assert Enum.map(service_list, &Map.get(&1, :name)) == ["proto2_features.Proto2Service"]
+      end
+
+      test "should list methods on our service", ctx do
+        message = {:file_containing_symbol, "proto2_features.Proto2Service"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "proto2_features"
+               } = response
+      end
+
+      test "proto2 required fields have LABEL_REQUIRED", ctx do
+        message = {:file_containing_symbol, "proto2_features.Proto2Request"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{name: "Proto2Request", field: fields}
+                 ]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+
+        assert %{label: :LABEL_REQUIRED, type: :TYPE_STRING, number: 1} =
+                 by_name["required_field"]
+
+        assert %{label: :LABEL_REQUIRED, type: :TYPE_INT32, number: 2} = by_name["required_id"]
+
+        assert %{label: :LABEL_OPTIONAL, type: :TYPE_STRING, number: 3} =
+                 by_name["optional_field"]
+
+        assert %{label: :LABEL_OPTIONAL, type: :TYPE_INT32, number: 4} = by_name["optional_id"]
+      end
+
+      test "proto2 default values are reflected", ctx do
+        message = {:file_containing_symbol, "proto2_features.Proto2Request"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{field: fields}
+                 ]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+        assert %{label: :LABEL_OPTIONAL, default_value: "unknown"} = by_name["name"]
+        assert %{label: :LABEL_OPTIONAL, default_value: "8080"} = by_name["port"]
+        assert %{label: :LABEL_OPTIONAL, default_value: "true"} = by_name["enabled"]
+        assert %{type: :TYPE_ENUM, default_value: "ACTIVE"} = by_name["status"]
+      end
+
+      test "proto2 oneof fields carry oneof_index", ctx do
+        message = {:file_containing_symbol, "proto2_features.Proto2Request"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{
+                     field: fields,
+                     oneof_decl: [%Google.Protobuf.OneofDescriptorProto{name: "proto2_oneof"}]
+                   }
+                 ]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+        assert %{oneof_index: 0} = by_name["oneof_string"]
+        assert %{oneof_index: 0} = by_name["oneof_int"]
+      end
+
+      test "proto2 packed repeated field has options.packed", ctx do
+        message = {:file_containing_symbol, "proto2_features.Proto2Request"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 message_type: [%Google.Protobuf.DescriptorProto{field: fields}]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+
+        assert %{
+                 label: :LABEL_REPEATED,
+                 type: :TYPE_INT32,
+                 options: %Google.Protobuf.FieldOptions{packed: true}
+               } = by_name["packed_ints"]
+      end
+
+      test "proto2 response required fields have LABEL_REQUIRED", ctx do
+        message = {:file_containing_symbol, "proto2_features.Proto2Response"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{name: "Proto2Response", field: fields}
+                 ]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+        assert %{label: :LABEL_REQUIRED, type: :TYPE_BOOL, number: 1} = by_name["success"]
+        assert %{label: :LABEL_OPTIONAL, type: :TYPE_STRING, number: 2} = by_name["message"]
+      end
+
+      @tag :skip
+      test "reflection graph is traversable using grpcurl", _ctx do
+        # MetadataMapEntry is a map-entry nested type. Without descriptor/0 the synthesized
+        # Proto2Request has nested_type: [] so MetadataMapEntry is emitted as a standalone
+        # file. grpcurl cannot resolve the cross-reference and returns exit code 1.
+        # This is a known synthesizer limitation for map fields with nested entry types.
+      end
+    end
+  end
+end

--- a/test/case/no_descriptor/recursive_message_test.exs
+++ b/test/case/no_descriptor/recursive_message_test.exs
@@ -1,0 +1,49 @@
+defmodule GrpcReflection.Case.NoDescriptor.RecursiveMessageTest do
+  @moduledoc false
+
+  use GrpcCase, service: NoDescriptor.RecursiveMessage.Service.Service
+
+  versions = ["v1", "v1alpha"]
+
+  for version <- versions do
+    describe version do
+      setup String.to_existing_atom("stub_#{version}_server")
+
+      test "should list services", ctx do
+        message = {:list_services, ""}
+        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+        assert Enum.map(service_list, &Map.get(&1, :name)) == ["recursive_message.Service"]
+      end
+
+      test "should list methods on our service with lowercase rpc name", ctx do
+        message = {:file_containing_symbol, "recursive_message.Service"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "recursive_message",
+                 service: [
+                   %Google.Protobuf.ServiceDescriptorProto{
+                     name: "Service",
+                     method: [
+                       %Google.Protobuf.MethodDescriptorProto{
+                         name: "call",
+                         input_type: ".recursive_message.Request",
+                         output_type: ".recursive_message.Reply",
+                         client_streaming: false,
+                         server_streaming: false
+                       }
+                     ]
+                   }
+                 ]
+               } = response
+      end
+
+      test "reflection graph is traversable using grpcurl", ctx do
+        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
+
+        assert {:call, "recursive_message.Service.call"} in ops
+        assert {:service, "recursive_message.Service"} in ops
+      end
+    end
+  end
+end

--- a/test/case/no_descriptor/recursive_message_test.exs
+++ b/test/case/no_descriptor/recursive_message_test.exs
@@ -3,47 +3,41 @@ defmodule GrpcReflection.Case.NoDescriptor.RecursiveMessageTest do
 
   use GrpcCase, service: NoDescriptor.RecursiveMessage.Service.Service
 
-  versions = ["v1", "v1alpha"]
+  setup :stub_v1_server
 
-  for version <- versions do
-    describe version do
-      setup String.to_existing_atom("stub_#{version}_server")
+  test "should list services", ctx do
+    message = {:list_services, ""}
+    assert {:ok, %{service: service_list}} = run_request(message, ctx)
+    assert Enum.map(service_list, &Map.get(&1, :name)) == ["recursive_message.Service"]
+  end
 
-      test "should list services", ctx do
-        message = {:list_services, ""}
-        assert {:ok, %{service: service_list}} = run_request(message, ctx)
-        assert Enum.map(service_list, &Map.get(&1, :name)) == ["recursive_message.Service"]
-      end
+  test "should list methods on our service with lowercase rpc name", ctx do
+    message = {:file_containing_symbol, "recursive_message.Service"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "should list methods on our service with lowercase rpc name", ctx do
-        message = {:file_containing_symbol, "recursive_message.Service"}
-        assert {:ok, response} = run_request(message, ctx)
-
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "recursive_message",
-                 service: [
-                   %Google.Protobuf.ServiceDescriptorProto{
-                     name: "Service",
-                     method: [
-                       %Google.Protobuf.MethodDescriptorProto{
-                         name: "call",
-                         input_type: ".recursive_message.Request",
-                         output_type: ".recursive_message.Reply",
-                         client_streaming: false,
-                         server_streaming: false
-                       }
-                     ]
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "recursive_message",
+             service: [
+               %Google.Protobuf.ServiceDescriptorProto{
+                 name: "Service",
+                 method: [
+                   %Google.Protobuf.MethodDescriptorProto{
+                     name: "call",
+                     input_type: ".recursive_message.Request",
+                     output_type: ".recursive_message.Reply",
+                     client_streaming: false,
+                     server_streaming: false
                    }
                  ]
-               } = response
-      end
+               }
+             ]
+           } = response
+  end
 
-      test "reflection graph is traversable using grpcurl", ctx do
-        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
+  test "reflection graph is traversable using grpcurl", ctx do
+    ops = GrpcReflection.TestClient.grpcurl_service(ctx)
 
-        assert {:call, "recursive_message.Service.call"} in ops
-        assert {:service, "recursive_message.Service"} in ops
-      end
-    end
+    assert {:call, "recursive_message.Service.call"} in ops
+    assert {:service, "recursive_message.Service"} in ops
   end
 end

--- a/test/case/no_descriptor/roundtrip/deprecated_fields_test.exs
+++ b/test/case/no_descriptor/roundtrip/deprecated_fields_test.exs
@@ -1,0 +1,40 @@
+defmodule GrpcReflection.Case.NoDescriptor.Roundtrip.DeprecatedFieldsTest do
+  @moduledoc false
+
+  # Handler echoes all four fields back so we can confirm that fields marked
+  # deprecated: true in FieldOptions encode and decode identically to active fields.
+  defmodule Handler do
+    use GRPC.Server, service: NoDescriptor.DeprecatedFields.DeprecatedFieldsService.Service
+
+    alias NoDescriptor.DeprecatedFields.DeprecatedResponse
+
+    def process(req, _stream) do
+      %DeprecatedResponse{
+        success: true,
+        result: req.active_field,
+        old_result: req.legacy_field
+      }
+    end
+  end
+
+  use GrpcCase,
+    service: NoDescriptor.DeprecatedFields.DeprecatedFieldsService.Service,
+    handler: Handler
+
+  describe "v1" do
+    setup :stub_v1_server
+
+    test "deprecated fields round-trip identically to active fields", ctx do
+      response =
+        GrpcReflection.TestClient.grpcurl_call(
+          ctx,
+          "deprecated_fields.DeprecatedFieldsService/Process",
+          %{"activeField" => "active_value", "legacyField" => "legacy_value"}
+        )
+
+      assert response["success"] == true
+      assert response["result"] == "active_value"
+      assert response["oldResult"] == "legacy_value"
+    end
+  end
+end

--- a/test/case/no_descriptor/roundtrip/recursive_message_test.exs
+++ b/test/case/no_descriptor/roundtrip/recursive_message_test.exs
@@ -1,0 +1,39 @@
+defmodule GrpcReflection.Case.NoDescriptor.Roundtrip.RecursiveMessageTest do
+  @moduledoc false
+
+  # Handler that echoes the reply back inside the reply's own request field,
+  # exercising embedded TYPE_MESSAGE encoding via the synthesized descriptor.
+  # The lowercase :call method name is also what caught bug #1 (Macro.camelize).
+  defmodule Handler do
+    use GRPC.Server, service: NoDescriptor.RecursiveMessage.Service.Service
+
+    alias NoDescriptor.RecursiveMessage.{Reply, Request}
+
+    def call(req, _stream) do
+      %Reply{request: %Request{reply: %Reply{request: req}}}
+    end
+  end
+
+  use GrpcCase,
+    service: NoDescriptor.RecursiveMessage.Service.Service,
+    handler: Handler
+
+  describe "v1" do
+    setup :stub_v1_server
+
+    test "roundtrip encodes and decodes embedded message fields correctly", ctx do
+      response =
+        GrpcReflection.TestClient.grpcurl_call(
+          ctx,
+          "recursive_message.Service/call",
+          %{}
+        )
+
+      # The handler wraps the request two levels deep — confirm the nested structure
+      # decoded correctly via the synthesized descriptor.
+      assert is_map(response["request"])
+      assert is_map(response["request"]["reply"])
+      assert is_map(response["request"]["reply"]["request"])
+    end
+  end
+end

--- a/test/case/no_descriptor/roundtrip/scalar_types_test.exs
+++ b/test/case/no_descriptor/roundtrip/scalar_types_test.exs
@@ -1,0 +1,48 @@
+defmodule GrpcReflection.Case.NoDescriptor.Roundtrip.ScalarTypesTest do
+  @moduledoc false
+
+  # Handler that echoes a representative sample of scalar field values back in the reply.
+  # Covers TYPE_INT32, TYPE_STRING, TYPE_BOOL, TYPE_DOUBLE, and TYPE_BYTES — enough to
+  # confirm that field numbers and types in the synthesized descriptor are correct.
+  defmodule Handler do
+    use GRPC.Server, service: NoDescriptor.ScalarTypes.ScalarService.Service
+
+    alias NoDescriptor.ScalarTypes.ScalarReply
+
+    def process_scalars(req, _stream) do
+      %ScalarReply{
+        int32_list: [req.int32_field],
+        string_list: [req.string_field],
+        bool_list: [req.bool_field],
+        double_list: [req.double_field],
+        bytes_list: [req.bytes_field]
+      }
+    end
+  end
+
+  use GrpcCase, service: NoDescriptor.ScalarTypes.ScalarService.Service, handler: Handler
+
+  describe "v1" do
+    setup :stub_v1_server
+
+    test "roundtrip encodes and decodes scalar field values correctly", ctx do
+      response =
+        GrpcReflection.TestClient.grpcurl_call(
+          ctx,
+          "scalar_types.ScalarService/ProcessScalars",
+          %{
+            "int32Field" => 42,
+            "stringField" => "hello",
+            "boolField" => true,
+            "doubleField" => 3.14,
+            "bytesField" => Base.encode64("bytes")
+          }
+        )
+
+      assert response["int32List"] == [42]
+      assert response["stringList"] == ["hello"]
+      assert response["boolList"] == [true]
+      assert_in_delta hd(response["doubleList"]), 3.14, 0.0001
+    end
+  end
+end

--- a/test/case/no_descriptor/scalar_types_test.exs
+++ b/test/case/no_descriptor/scalar_types_test.exs
@@ -1,0 +1,135 @@
+defmodule GrpcReflection.Case.NoDescriptor.ScalarTypesTest do
+  @moduledoc false
+
+  use GrpcCase, service: NoDescriptor.ScalarTypes.ScalarService.Service
+
+  versions = ["v1", "v1alpha"]
+
+  for version <- versions do
+    describe version do
+      setup String.to_existing_atom("stub_#{version}_server")
+
+      test "should list services", ctx do
+        message = {:list_services, ""}
+        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+        assert Enum.map(service_list, &Map.get(&1, :name)) == ["scalar_types.ScalarService"]
+      end
+
+      test "should list methods on our service", ctx do
+        message = {:file_containing_symbol, "scalar_types.ScalarService"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "scalar_types",
+                 service: [
+                   %Google.Protobuf.ServiceDescriptorProto{
+                     name: "ScalarService",
+                     method: [
+                       %Google.Protobuf.MethodDescriptorProto{
+                         name: "ProcessScalars",
+                         input_type: ".scalar_types.ScalarRequest",
+                         output_type: ".scalar_types.ScalarReply",
+                         client_streaming: false,
+                         server_streaming: false
+                       }
+                     ]
+                   }
+                 ]
+               } = response
+      end
+
+      test "should reflect all scalar field types on ScalarRequest", ctx do
+        message = {:file_containing_symbol, "scalar_types.ScalarRequest"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "scalar_types",
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{
+                     name: "ScalarRequest",
+                     field: fields
+                   }
+                 ]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+
+        assert %{type: :TYPE_DOUBLE, number: 1, label: :LABEL_OPTIONAL} = by_name["double_field"]
+        assert %{type: :TYPE_FLOAT, number: 2, label: :LABEL_OPTIONAL} = by_name["float_field"]
+        assert %{type: :TYPE_INT32, number: 3, label: :LABEL_OPTIONAL} = by_name["int32_field"]
+        assert %{type: :TYPE_INT64, number: 4, label: :LABEL_OPTIONAL} = by_name["int64_field"]
+        assert %{type: :TYPE_UINT32, number: 5, label: :LABEL_OPTIONAL} = by_name["uint32_field"]
+        assert %{type: :TYPE_UINT64, number: 6, label: :LABEL_OPTIONAL} = by_name["uint64_field"]
+        assert %{type: :TYPE_SINT32, number: 7, label: :LABEL_OPTIONAL} = by_name["sint32_field"]
+        assert %{type: :TYPE_SINT64, number: 8, label: :LABEL_OPTIONAL} = by_name["sint64_field"]
+
+        assert %{type: :TYPE_FIXED32, number: 9, label: :LABEL_OPTIONAL} =
+                 by_name["fixed32_field"]
+
+        assert %{type: :TYPE_FIXED64, number: 10, label: :LABEL_OPTIONAL} =
+                 by_name["fixed64_field"]
+
+        assert %{type: :TYPE_SFIXED32, number: 11, label: :LABEL_OPTIONAL} =
+                 by_name["sfixed32_field"]
+
+        assert %{type: :TYPE_SFIXED64, number: 12, label: :LABEL_OPTIONAL} =
+                 by_name["sfixed64_field"]
+
+        assert %{type: :TYPE_BOOL, number: 13, label: :LABEL_OPTIONAL} = by_name["bool_field"]
+        assert %{type: :TYPE_STRING, number: 14, label: :LABEL_OPTIONAL} = by_name["string_field"]
+        assert %{type: :TYPE_BYTES, number: 15, label: :LABEL_OPTIONAL} = by_name["bytes_field"]
+
+        assert %{type: :TYPE_STRING, number: 100, label: :LABEL_OPTIONAL} =
+                 by_name["sparse_field_1"]
+
+        assert %{type: :TYPE_STRING, number: 1000, label: :LABEL_OPTIONAL} =
+                 by_name["sparse_field_2"]
+
+        assert %{type: :TYPE_STRING, number: 10_000, label: :LABEL_OPTIONAL} =
+                 by_name["sparse_field_3"]
+      end
+
+      test "should reflect proto3 optional fields with presence tracking", ctx do
+        message = {:file_containing_symbol, "scalar_types.ScalarRequest"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 message_type: [%Google.Protobuf.DescriptorProto{field: fields}]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+
+        assert %{type: :TYPE_STRING, number: 18, proto3_optional: true} =
+                 by_name["optional_string"]
+
+        assert %{type: :TYPE_INT32, number: 19, proto3_optional: true} = by_name["optional_int"]
+      end
+
+      test "should reflect repeated fields on ScalarReply", ctx do
+        message = {:file_containing_symbol, "scalar_types.ScalarReply"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{name: "ScalarReply", field: fields}
+                 ]
+               } = response
+
+        assert Enum.all?(fields, &(&1.label == :LABEL_REPEATED))
+        by_name = Map.new(fields, &{&1.name, &1})
+        assert %{type: :TYPE_DOUBLE} = by_name["double_list"]
+        assert %{type: :TYPE_BYTES} = by_name["bytes_list"]
+        assert %{type: :TYPE_BOOL} = by_name["bool_list"]
+      end
+
+      test "reflection graph is traversable using grpcurl", ctx do
+        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
+
+        assert ops == [
+                 {:call, "scalar_types.ScalarService.ProcessScalars"},
+                 {:service, "scalar_types.ScalarService"}
+               ]
+      end
+    end
+  end
+end

--- a/test/case/no_descriptor/scalar_types_test.exs
+++ b/test/case/no_descriptor/scalar_types_test.exs
@@ -3,133 +3,120 @@ defmodule GrpcReflection.Case.NoDescriptor.ScalarTypesTest do
 
   use GrpcCase, service: NoDescriptor.ScalarTypes.ScalarService.Service
 
-  versions = ["v1", "v1alpha"]
+  setup :stub_v1_server
 
-  for version <- versions do
-    describe version do
-      setup String.to_existing_atom("stub_#{version}_server")
+  test "should list services", ctx do
+    message = {:list_services, ""}
+    assert {:ok, %{service: service_list}} = run_request(message, ctx)
+    assert Enum.map(service_list, &Map.get(&1, :name)) == ["scalar_types.ScalarService"]
+  end
 
-      test "should list services", ctx do
-        message = {:list_services, ""}
-        assert {:ok, %{service: service_list}} = run_request(message, ctx)
-        assert Enum.map(service_list, &Map.get(&1, :name)) == ["scalar_types.ScalarService"]
-      end
+  test "should list methods on our service", ctx do
+    message = {:file_containing_symbol, "scalar_types.ScalarService"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "should list methods on our service", ctx do
-        message = {:file_containing_symbol, "scalar_types.ScalarService"}
-        assert {:ok, response} = run_request(message, ctx)
-
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "scalar_types",
-                 service: [
-                   %Google.Protobuf.ServiceDescriptorProto{
-                     name: "ScalarService",
-                     method: [
-                       %Google.Protobuf.MethodDescriptorProto{
-                         name: "ProcessScalars",
-                         input_type: ".scalar_types.ScalarRequest",
-                         output_type: ".scalar_types.ScalarReply",
-                         client_streaming: false,
-                         server_streaming: false
-                       }
-                     ]
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "scalar_types",
+             service: [
+               %Google.Protobuf.ServiceDescriptorProto{
+                 name: "ScalarService",
+                 method: [
+                   %Google.Protobuf.MethodDescriptorProto{
+                     name: "ProcessScalars",
+                     input_type: ".scalar_types.ScalarRequest",
+                     output_type: ".scalar_types.ScalarReply",
+                     client_streaming: false,
+                     server_streaming: false
                    }
                  ]
-               } = response
-      end
+               }
+             ]
+           } = response
+  end
 
-      test "should reflect all scalar field types on ScalarRequest", ctx do
-        message = {:file_containing_symbol, "scalar_types.ScalarRequest"}
-        assert {:ok, response} = run_request(message, ctx)
+  test "should reflect all scalar field types on ScalarRequest", ctx do
+    message = {:file_containing_symbol, "scalar_types.ScalarRequest"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "scalar_types",
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{
-                     name: "ScalarRequest",
-                     field: fields
-                   }
-                 ]
-               } = response
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "scalar_types",
+             message_type: [
+               %Google.Protobuf.DescriptorProto{
+                 name: "ScalarRequest",
+                 field: fields
+               }
+             ]
+           } = response
 
-        by_name = Map.new(fields, &{&1.name, &1})
+    by_name = Map.new(fields, &{&1.name, &1})
 
-        assert %{type: :TYPE_DOUBLE, number: 1, label: :LABEL_OPTIONAL} = by_name["double_field"]
-        assert %{type: :TYPE_FLOAT, number: 2, label: :LABEL_OPTIONAL} = by_name["float_field"]
-        assert %{type: :TYPE_INT32, number: 3, label: :LABEL_OPTIONAL} = by_name["int32_field"]
-        assert %{type: :TYPE_INT64, number: 4, label: :LABEL_OPTIONAL} = by_name["int64_field"]
-        assert %{type: :TYPE_UINT32, number: 5, label: :LABEL_OPTIONAL} = by_name["uint32_field"]
-        assert %{type: :TYPE_UINT64, number: 6, label: :LABEL_OPTIONAL} = by_name["uint64_field"]
-        assert %{type: :TYPE_SINT32, number: 7, label: :LABEL_OPTIONAL} = by_name["sint32_field"]
-        assert %{type: :TYPE_SINT64, number: 8, label: :LABEL_OPTIONAL} = by_name["sint64_field"]
+    assert %{type: :TYPE_DOUBLE, number: 1, label: :LABEL_OPTIONAL} = by_name["double_field"]
+    assert %{type: :TYPE_FLOAT, number: 2, label: :LABEL_OPTIONAL} = by_name["float_field"]
+    assert %{type: :TYPE_INT32, number: 3, label: :LABEL_OPTIONAL} = by_name["int32_field"]
+    assert %{type: :TYPE_INT64, number: 4, label: :LABEL_OPTIONAL} = by_name["int64_field"]
+    assert %{type: :TYPE_UINT32, number: 5, label: :LABEL_OPTIONAL} = by_name["uint32_field"]
+    assert %{type: :TYPE_UINT64, number: 6, label: :LABEL_OPTIONAL} = by_name["uint64_field"]
+    assert %{type: :TYPE_SINT32, number: 7, label: :LABEL_OPTIONAL} = by_name["sint32_field"]
+    assert %{type: :TYPE_SINT64, number: 8, label: :LABEL_OPTIONAL} = by_name["sint64_field"]
+    assert %{type: :TYPE_FIXED32, number: 9, label: :LABEL_OPTIONAL} = by_name["fixed32_field"]
+    assert %{type: :TYPE_FIXED64, number: 10, label: :LABEL_OPTIONAL} = by_name["fixed64_field"]
 
-        assert %{type: :TYPE_FIXED32, number: 9, label: :LABEL_OPTIONAL} =
-                 by_name["fixed32_field"]
+    assert %{type: :TYPE_SFIXED32, number: 11, label: :LABEL_OPTIONAL} =
+             by_name["sfixed32_field"]
 
-        assert %{type: :TYPE_FIXED64, number: 10, label: :LABEL_OPTIONAL} =
-                 by_name["fixed64_field"]
+    assert %{type: :TYPE_SFIXED64, number: 12, label: :LABEL_OPTIONAL} =
+             by_name["sfixed64_field"]
 
-        assert %{type: :TYPE_SFIXED32, number: 11, label: :LABEL_OPTIONAL} =
-                 by_name["sfixed32_field"]
+    assert %{type: :TYPE_BOOL, number: 13, label: :LABEL_OPTIONAL} = by_name["bool_field"]
+    assert %{type: :TYPE_STRING, number: 14, label: :LABEL_OPTIONAL} = by_name["string_field"]
+    assert %{type: :TYPE_BYTES, number: 15, label: :LABEL_OPTIONAL} = by_name["bytes_field"]
 
-        assert %{type: :TYPE_SFIXED64, number: 12, label: :LABEL_OPTIONAL} =
-                 by_name["sfixed64_field"]
+    assert %{type: :TYPE_STRING, number: 100, label: :LABEL_OPTIONAL} = by_name["sparse_field_1"]
 
-        assert %{type: :TYPE_BOOL, number: 13, label: :LABEL_OPTIONAL} = by_name["bool_field"]
-        assert %{type: :TYPE_STRING, number: 14, label: :LABEL_OPTIONAL} = by_name["string_field"]
-        assert %{type: :TYPE_BYTES, number: 15, label: :LABEL_OPTIONAL} = by_name["bytes_field"]
+    assert %{type: :TYPE_STRING, number: 1000, label: :LABEL_OPTIONAL} =
+             by_name["sparse_field_2"]
 
-        assert %{type: :TYPE_STRING, number: 100, label: :LABEL_OPTIONAL} =
-                 by_name["sparse_field_1"]
+    assert %{type: :TYPE_STRING, number: 10_000, label: :LABEL_OPTIONAL} =
+             by_name["sparse_field_3"]
+  end
 
-        assert %{type: :TYPE_STRING, number: 1000, label: :LABEL_OPTIONAL} =
-                 by_name["sparse_field_2"]
+  test "should reflect proto3 optional fields with presence tracking", ctx do
+    message = {:file_containing_symbol, "scalar_types.ScalarRequest"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %{type: :TYPE_STRING, number: 10_000, label: :LABEL_OPTIONAL} =
-                 by_name["sparse_field_3"]
-      end
+    assert %Google.Protobuf.FileDescriptorProto{
+             message_type: [%Google.Protobuf.DescriptorProto{field: fields}]
+           } = response
 
-      test "should reflect proto3 optional fields with presence tracking", ctx do
-        message = {:file_containing_symbol, "scalar_types.ScalarRequest"}
-        assert {:ok, response} = run_request(message, ctx)
+    by_name = Map.new(fields, &{&1.name, &1})
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 message_type: [%Google.Protobuf.DescriptorProto{field: fields}]
-               } = response
+    assert %{type: :TYPE_STRING, number: 18, proto3_optional: true} = by_name["optional_string"]
+    assert %{type: :TYPE_INT32, number: 19, proto3_optional: true} = by_name["optional_int"]
+  end
 
-        by_name = Map.new(fields, &{&1.name, &1})
+  test "should reflect repeated fields on ScalarReply", ctx do
+    message = {:file_containing_symbol, "scalar_types.ScalarReply"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %{type: :TYPE_STRING, number: 18, proto3_optional: true} =
-                 by_name["optional_string"]
+    assert %Google.Protobuf.FileDescriptorProto{
+             message_type: [
+               %Google.Protobuf.DescriptorProto{name: "ScalarReply", field: fields}
+             ]
+           } = response
 
-        assert %{type: :TYPE_INT32, number: 19, proto3_optional: true} = by_name["optional_int"]
-      end
+    assert Enum.all?(fields, &(&1.label == :LABEL_REPEATED))
+    by_name = Map.new(fields, &{&1.name, &1})
+    assert %{type: :TYPE_DOUBLE} = by_name["double_list"]
+    assert %{type: :TYPE_BYTES} = by_name["bytes_list"]
+    assert %{type: :TYPE_BOOL} = by_name["bool_list"]
+  end
 
-      test "should reflect repeated fields on ScalarReply", ctx do
-        message = {:file_containing_symbol, "scalar_types.ScalarReply"}
-        assert {:ok, response} = run_request(message, ctx)
+  test "reflection graph is traversable using grpcurl", ctx do
+    ops = GrpcReflection.TestClient.grpcurl_service(ctx)
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{name: "ScalarReply", field: fields}
-                 ]
-               } = response
-
-        assert Enum.all?(fields, &(&1.label == :LABEL_REPEATED))
-        by_name = Map.new(fields, &{&1.name, &1})
-        assert %{type: :TYPE_DOUBLE} = by_name["double_list"]
-        assert %{type: :TYPE_BYTES} = by_name["bytes_list"]
-        assert %{type: :TYPE_BOOL} = by_name["bool_list"]
-      end
-
-      test "reflection graph is traversable using grpcurl", ctx do
-        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
-
-        assert ops == [
-                 {:call, "scalar_types.ScalarService.ProcessScalars"},
-                 {:service, "scalar_types.ScalarService"}
-               ]
-      end
-    end
+    assert ops == [
+             {:call, "scalar_types.ScalarService.ProcessScalars"},
+             {:service, "scalar_types.ScalarService"}
+           ]
   end
 end

--- a/test/case/no_descriptor/streaming_service_test.exs
+++ b/test/case/no_descriptor/streaming_service_test.exs
@@ -3,55 +3,49 @@ defmodule GrpcReflection.Case.NoDescriptor.StreamingTest do
 
   use GrpcCase, service: NoDescriptor.Streaming.StreamingService.Service
 
-  versions = ["v1", "v1alpha"]
+  setup :stub_v1_server
 
-  for version <- versions do
-    describe version do
-      setup String.to_existing_atom("stub_#{version}_server")
+  test "should list services", ctx do
+    message = {:list_services, ""}
+    assert {:ok, %{service: service_list}} = run_request(message, ctx)
+    assert Enum.map(service_list, &Map.get(&1, :name)) == ["streaming.StreamingService"]
+  end
 
-      test "should list services", ctx do
-        message = {:list_services, ""}
-        assert {:ok, %{service: service_list}} = run_request(message, ctx)
-        assert Enum.map(service_list, &Map.get(&1, :name)) == ["streaming.StreamingService"]
-      end
+  test "should list methods on StreamingService with correct streaming flags", ctx do
+    message = {:file_containing_symbol, "streaming.StreamingService"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "should list methods on StreamingService with correct streaming flags", ctx do
-        message = {:file_containing_symbol, "streaming.StreamingService"}
-        assert {:ok, response} = run_request(message, ctx)
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "streaming",
+             service: [
+               %Google.Protobuf.ServiceDescriptorProto{
+                 name: "StreamingService",
+                 method: methods
+               }
+             ]
+           } = response
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "streaming",
-                 service: [
-                   %Google.Protobuf.ServiceDescriptorProto{
-                     name: "StreamingService",
-                     method: methods
-                   }
-                 ]
-               } = response
+    by_name = Map.new(methods, &{&1.name, &1})
 
-        by_name = Map.new(methods, &{&1.name, &1})
+    assert %{client_streaming: false, server_streaming: false} = by_name["UnaryCall"]
+    assert %{client_streaming: false, server_streaming: true} = by_name["ServerStreamingCall"]
+    assert %{client_streaming: true, server_streaming: false} = by_name["ClientStreamingCall"]
 
-        assert %{client_streaming: false, server_streaming: false} = by_name["UnaryCall"]
-        assert %{client_streaming: false, server_streaming: true} = by_name["ServerStreamingCall"]
-        assert %{client_streaming: true, server_streaming: false} = by_name["ClientStreamingCall"]
+    assert %{client_streaming: true, server_streaming: true} =
+             by_name["BidirectionalStreamingCall"]
+  end
 
-        assert %{client_streaming: true, server_streaming: true} =
-                 by_name["BidirectionalStreamingCall"]
-      end
+  test "reflection graph is traversable using grpcurl", ctx do
+    ops = GrpcReflection.TestClient.grpcurl_service(ctx)
 
-      test "reflection graph is traversable using grpcurl", ctx do
-        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
-
-        assert ops == [
-                 {:call, "streaming.StreamingService.BidirectionalStreamingCall"},
-                 {:call, "streaming.StreamingService.ClientStreamingCall"},
-                 {:call, "streaming.StreamingService.ServerStreamingCall"},
-                 {:call, "streaming.StreamingService.UnaryCall"},
-                 {:service, "streaming.StreamingService"},
-                 {:type, ".streaming.StreamRequest"},
-                 {:type, ".streaming.StreamResponse"}
-               ]
-      end
-    end
+    assert ops == [
+             {:call, "streaming.StreamingService.BidirectionalStreamingCall"},
+             {:call, "streaming.StreamingService.ClientStreamingCall"},
+             {:call, "streaming.StreamingService.ServerStreamingCall"},
+             {:call, "streaming.StreamingService.UnaryCall"},
+             {:service, "streaming.StreamingService"},
+             {:type, ".streaming.StreamRequest"},
+             {:type, ".streaming.StreamResponse"}
+           ]
   end
 end

--- a/test/case/no_descriptor/streaming_service_test.exs
+++ b/test/case/no_descriptor/streaming_service_test.exs
@@ -1,0 +1,57 @@
+defmodule GrpcReflection.Case.NoDescriptor.StreamingTest do
+  @moduledoc false
+
+  use GrpcCase, service: NoDescriptor.Streaming.StreamingService.Service
+
+  versions = ["v1", "v1alpha"]
+
+  for version <- versions do
+    describe version do
+      setup String.to_existing_atom("stub_#{version}_server")
+
+      test "should list services", ctx do
+        message = {:list_services, ""}
+        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+        assert Enum.map(service_list, &Map.get(&1, :name)) == ["streaming.StreamingService"]
+      end
+
+      test "should list methods on StreamingService with correct streaming flags", ctx do
+        message = {:file_containing_symbol, "streaming.StreamingService"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "streaming",
+                 service: [
+                   %Google.Protobuf.ServiceDescriptorProto{
+                     name: "StreamingService",
+                     method: methods
+                   }
+                 ]
+               } = response
+
+        by_name = Map.new(methods, &{&1.name, &1})
+
+        assert %{client_streaming: false, server_streaming: false} = by_name["UnaryCall"]
+        assert %{client_streaming: false, server_streaming: true} = by_name["ServerStreamingCall"]
+        assert %{client_streaming: true, server_streaming: false} = by_name["ClientStreamingCall"]
+
+        assert %{client_streaming: true, server_streaming: true} =
+                 by_name["BidirectionalStreamingCall"]
+      end
+
+      test "reflection graph is traversable using grpcurl", ctx do
+        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
+
+        assert ops == [
+                 {:call, "streaming.StreamingService.BidirectionalStreamingCall"},
+                 {:call, "streaming.StreamingService.ClientStreamingCall"},
+                 {:call, "streaming.StreamingService.ServerStreamingCall"},
+                 {:call, "streaming.StreamingService.UnaryCall"},
+                 {:service, "streaming.StreamingService"},
+                 {:type, ".streaming.StreamRequest"},
+                 {:type, ".streaming.StreamResponse"}
+               ]
+      end
+    end
+  end
+end

--- a/test/case/no_descriptor/well_known_types_test.exs
+++ b/test/case/no_descriptor/well_known_types_test.exs
@@ -3,97 +3,91 @@ defmodule GrpcReflection.Case.NoDescriptor.WellKnownTypesTest do
 
   use GrpcCase, service: NoDescriptor.WellKnownTypes.WellKnownTypesService.Service
 
-  versions = ["v1", "v1alpha"]
+  setup :stub_v1_server
 
-  for version <- versions do
-    describe version do
-      setup String.to_existing_atom("stub_#{version}_server")
+  test "should list services", ctx do
+    message = {:list_services, ""}
+    assert {:ok, %{service: service_list}} = run_request(message, ctx)
 
-      test "should list services", ctx do
-        message = {:list_services, ""}
-        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+    assert Enum.map(service_list, &Map.get(&1, :name)) == [
+             "well_known_types.WellKnownTypesService"
+           ]
+  end
 
-        assert Enum.map(service_list, &Map.get(&1, :name)) == [
-                 "well_known_types.WellKnownTypesService"
-               ]
-      end
+  test "should list methods on our service", ctx do
+    message = {:file_containing_symbol, "well_known_types.WellKnownTypesService"}
+    assert {:ok, response} = run_request(message, ctx)
 
-      test "should list methods on our service", ctx do
-        message = {:file_containing_symbol, "well_known_types.WellKnownTypesService"}
-        assert {:ok, response} = run_request(message, ctx)
-
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "well_known_types",
-                 service: [
-                   %Google.Protobuf.ServiceDescriptorProto{
-                     name: "WellKnownTypesService",
-                     method: [
-                       %Google.Protobuf.MethodDescriptorProto{
-                         name: "ProcessWellKnownTypes",
-                         input_type: ".well_known_types.WellKnownRequest",
-                         output_type: ".well_known_types.WellKnownResponse"
-                       },
-                       %Google.Protobuf.MethodDescriptorProto{
-                         name: "EmptyMethod",
-                         input_type: ".google.protobuf.Empty",
-                         output_type: ".google.protobuf.Empty"
-                       }
-                     ]
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "well_known_types",
+             service: [
+               %Google.Protobuf.ServiceDescriptorProto{
+                 name: "WellKnownTypesService",
+                 method: [
+                   %Google.Protobuf.MethodDescriptorProto{
+                     name: "ProcessWellKnownTypes",
+                     input_type: ".well_known_types.WellKnownRequest",
+                     output_type: ".well_known_types.WellKnownResponse"
+                   },
+                   %Google.Protobuf.MethodDescriptorProto{
+                     name: "EmptyMethod",
+                     input_type: ".google.protobuf.Empty",
+                     output_type: ".google.protobuf.Empty"
                    }
                  ]
-               } = response
-      end
+               }
+             ]
+           } = response
+  end
 
-      test "well-known type Timestamp is resolvable by symbol", ctx do
-        message = {:file_containing_symbol, "google.protobuf.Timestamp"}
-        assert {:ok, response} = run_request(message, ctx)
+  test "well-known type Timestamp is resolvable by symbol", ctx do
+    message = {:file_containing_symbol, "google.protobuf.Timestamp"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "google.protobuf",
-                 message_type: [%Google.Protobuf.DescriptorProto{name: "Timestamp"}]
-               } = response
-      end
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "google.protobuf",
+             message_type: [%Google.Protobuf.DescriptorProto{name: "Timestamp"}]
+           } = response
+  end
 
-      test "well-known type Any is resolvable by symbol", ctx do
-        message = {:file_containing_symbol, "google.protobuf.Any"}
-        assert {:ok, response} = run_request(message, ctx)
+  test "well-known type Any is resolvable by symbol", ctx do
+    message = {:file_containing_symbol, "google.protobuf.Any"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "google.protobuf",
-                 message_type: [%Google.Protobuf.DescriptorProto{name: "Any"}]
-               } = response
-      end
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "google.protobuf",
+             message_type: [%Google.Protobuf.DescriptorProto{name: "Any"}]
+           } = response
+  end
 
-      test "WellKnownRequest fields reference google.protobuf types", ctx do
-        message = {:file_containing_symbol, "well_known_types.WellKnownRequest"}
-        assert {:ok, response} = run_request(message, ctx)
+  test "WellKnownRequest fields reference google.protobuf types", ctx do
+    message = {:file_containing_symbol, "well_known_types.WellKnownRequest"}
+    assert {:ok, response} = run_request(message, ctx)
 
-        assert %Google.Protobuf.FileDescriptorProto{
-                 package: "well_known_types",
-                 message_type: [
-                   %Google.Protobuf.DescriptorProto{name: "WellKnownRequest", field: fields}
-                 ]
-               } = response
+    assert %Google.Protobuf.FileDescriptorProto{
+             package: "well_known_types",
+             message_type: [
+               %Google.Protobuf.DescriptorProto{name: "WellKnownRequest", field: fields}
+             ]
+           } = response
 
-        by_name = Map.new(fields, &{&1.name, &1})
-        assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.Any"} = by_name["payload"]
+    by_name = Map.new(fields, &{&1.name, &1})
+    assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.Any"} = by_name["payload"]
 
-        assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.Timestamp"} =
-                 by_name["created_at"]
+    assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.Timestamp"} =
+             by_name["created_at"]
 
-        assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.Duration"} = by_name["timeout"]
+    assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.Duration"} = by_name["timeout"]
 
-        assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.FieldMask"} =
-                 by_name["field_mask"]
-      end
+    assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.FieldMask"} =
+             by_name["field_mask"]
+  end
 
-      test "reflection graph is traversable using grpcurl", ctx do
-        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
+  test "reflection graph is traversable using grpcurl", ctx do
+    ops = GrpcReflection.TestClient.grpcurl_service(ctx)
 
-        assert {:call, "well_known_types.WellKnownTypesService.ProcessWellKnownTypes"} in ops
-        assert {:call, "well_known_types.WellKnownTypesService.EmptyMethod"} in ops
-        assert {:service, "well_known_types.WellKnownTypesService"} in ops
-      end
-    end
+    assert {:call, "well_known_types.WellKnownTypesService.ProcessWellKnownTypes"} in ops
+    assert {:call, "well_known_types.WellKnownTypesService.EmptyMethod"} in ops
+    assert {:service, "well_known_types.WellKnownTypesService"} in ops
   end
 end

--- a/test/case/no_descriptor/well_known_types_test.exs
+++ b/test/case/no_descriptor/well_known_types_test.exs
@@ -1,0 +1,99 @@
+defmodule GrpcReflection.Case.NoDescriptor.WellKnownTypesTest do
+  @moduledoc false
+
+  use GrpcCase, service: NoDescriptor.WellKnownTypes.WellKnownTypesService.Service
+
+  versions = ["v1", "v1alpha"]
+
+  for version <- versions do
+    describe version do
+      setup String.to_existing_atom("stub_#{version}_server")
+
+      test "should list services", ctx do
+        message = {:list_services, ""}
+        assert {:ok, %{service: service_list}} = run_request(message, ctx)
+
+        assert Enum.map(service_list, &Map.get(&1, :name)) == [
+                 "well_known_types.WellKnownTypesService"
+               ]
+      end
+
+      test "should list methods on our service", ctx do
+        message = {:file_containing_symbol, "well_known_types.WellKnownTypesService"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "well_known_types",
+                 service: [
+                   %Google.Protobuf.ServiceDescriptorProto{
+                     name: "WellKnownTypesService",
+                     method: [
+                       %Google.Protobuf.MethodDescriptorProto{
+                         name: "ProcessWellKnownTypes",
+                         input_type: ".well_known_types.WellKnownRequest",
+                         output_type: ".well_known_types.WellKnownResponse"
+                       },
+                       %Google.Protobuf.MethodDescriptorProto{
+                         name: "EmptyMethod",
+                         input_type: ".google.protobuf.Empty",
+                         output_type: ".google.protobuf.Empty"
+                       }
+                     ]
+                   }
+                 ]
+               } = response
+      end
+
+      test "well-known type Timestamp is resolvable by symbol", ctx do
+        message = {:file_containing_symbol, "google.protobuf.Timestamp"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "google.protobuf",
+                 message_type: [%Google.Protobuf.DescriptorProto{name: "Timestamp"}]
+               } = response
+      end
+
+      test "well-known type Any is resolvable by symbol", ctx do
+        message = {:file_containing_symbol, "google.protobuf.Any"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "google.protobuf",
+                 message_type: [%Google.Protobuf.DescriptorProto{name: "Any"}]
+               } = response
+      end
+
+      test "WellKnownRequest fields reference google.protobuf types", ctx do
+        message = {:file_containing_symbol, "well_known_types.WellKnownRequest"}
+        assert {:ok, response} = run_request(message, ctx)
+
+        assert %Google.Protobuf.FileDescriptorProto{
+                 package: "well_known_types",
+                 message_type: [
+                   %Google.Protobuf.DescriptorProto{name: "WellKnownRequest", field: fields}
+                 ]
+               } = response
+
+        by_name = Map.new(fields, &{&1.name, &1})
+        assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.Any"} = by_name["payload"]
+
+        assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.Timestamp"} =
+                 by_name["created_at"]
+
+        assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.Duration"} = by_name["timeout"]
+
+        assert %{type: :TYPE_MESSAGE, type_name: ".google.protobuf.FieldMask"} =
+                 by_name["field_mask"]
+      end
+
+      test "reflection graph is traversable using grpcurl", ctx do
+        ops = GrpcReflection.TestClient.grpcurl_service(ctx)
+
+        assert {:call, "well_known_types.WellKnownTypesService.ProcessWellKnownTypes"} in ops
+        assert {:call, "well_known_types.WellKnownTypesService.EmptyMethod"} in ops
+        assert {:service, "well_known_types.WellKnownTypesService"} in ops
+      end
+    end
+  end
+end

--- a/test/service/builder/synthesizer_test.exs
+++ b/test/service/builder/synthesizer_test.exs
@@ -25,10 +25,12 @@ defmodule GrpcReflection.Service.Builder.SynthesizerTest do
     |> Map.update(:options, nil, &normalize_options/1)
   end
 
-  # The real descriptor populates many FieldOptions fields with defaults (ctype, deprecated,
-  # lazy, etc). We only synthesize packed, so normalize to just that for comparison.
+  # The real descriptor populates many FieldOptions fields with defaults (ctype, lazy, etc).
+  # We only synthesize packed and deprecated, so normalize to just those for comparison.
   defp normalize_options(nil), do: nil
-  defp normalize_options(%Google.Protobuf.FieldOptions{packed: packed}), do: %{packed: packed}
+
+  defp normalize_options(%Google.Protobuf.FieldOptions{packed: packed, deprecated: deprecated}),
+    do: %{packed: packed, deprecated: deprecated || nil}
 
   defp comparable_fields(descriptor), do: Enum.map(descriptor.field, &comparable_field/1)
 
@@ -89,6 +91,14 @@ defmodule GrpcReflection.Service.Builder.SynthesizerTest do
       real_decl_names = Enum.map(real.oneof_decl, & &1.name)
       synth_decl_names = Enum.map(synth.oneof_decl, & &1.name)
       assert real_decl_names == synth_decl_names
+    end
+
+    test "DeprecatedRequest fields match protoc output" do
+      real = DeprecatedFields.DeprecatedRequest.descriptor()
+      synth = Synthesizer.message_descriptor(NoDescriptor.DeprecatedFields.DeprecatedRequest)
+
+      assert synth.name == real.name
+      assert comparable_fields(synth) == comparable_fields(real)
     end
   end
 

--- a/test/service/builder/synthesizer_test.exs
+++ b/test/service/builder/synthesizer_test.exs
@@ -1,0 +1,135 @@
+defmodule GrpcReflection.Service.Builder.SynthesizerTest do
+  use ExUnit.Case, async: true
+
+  alias GrpcReflection.Service.Builder.Synthesizer
+
+  # Fields that reflection clients care about. We exclude:
+  # - proto3_optional: proto2 real descriptors use nil, synthesizer uses false — both falsy
+  # - __unknown_fields__: internal protobuf bookkeeping
+  @comparable_field_keys [
+    :name,
+    :number,
+    :type,
+    :label,
+    :type_name,
+    :default_value,
+    :oneof_index,
+    :options,
+    :json_name,
+    :extendee
+  ]
+
+  defp comparable_field(f) do
+    f
+    |> Map.take(@comparable_field_keys)
+    |> Map.update(:options, nil, &normalize_options/1)
+  end
+
+  # The real descriptor populates many FieldOptions fields with defaults (ctype, deprecated,
+  # lazy, etc). We only synthesize packed, so normalize to just that for comparison.
+  defp normalize_options(nil), do: nil
+  defp normalize_options(%Google.Protobuf.FieldOptions{packed: packed}), do: %{packed: packed}
+
+  defp comparable_fields(descriptor), do: Enum.map(descriptor.field, &comparable_field/1)
+
+  describe "field_descriptor_from_props/1" do
+    test "proto3_optional field has proto3_optional true but no oneof_index at this level" do
+      # oneof_index for proto3_optional is assigned in message_descriptor/1, not here,
+      # because the synthetic index depends on how many real oneofs precede it.
+      props = NoDescriptor.ScalarTypes.ScalarRequest.__message_props__().field_props[18]
+
+      assert %Google.Protobuf.FieldDescriptorProto{
+               name: "optional_string",
+               proto3_optional: true,
+               oneof_index: nil
+             } = Synthesizer.field_descriptor_from_props(props)
+    end
+  end
+
+  describe "message_descriptor/1 matches real descriptor" do
+    test "Proto2Request fields match protoc output" do
+      real = Proto2Features.Proto2Request.descriptor()
+      synth = Synthesizer.message_descriptor(NoDescriptor.Proto2Features.Proto2Request)
+
+      assert synth.name == real.name
+      assert synth.oneof_decl == real.oneof_decl
+      assert synth.extension_range == real.extension_range
+      assert comparable_fields(synth) == comparable_fields(real)
+    end
+
+    test "ScalarRequest fields match protoc output" do
+      real = ScalarTypes.ScalarRequest.descriptor()
+      synth = Synthesizer.message_descriptor(NoDescriptor.ScalarTypes.ScalarRequest)
+
+      assert synth.name == real.name
+      assert comparable_fields(synth) == comparable_fields(real)
+    end
+
+    test "ScalarReply fields match protoc output" do
+      real = ScalarTypes.ScalarReply.descriptor()
+      synth = Synthesizer.message_descriptor(NoDescriptor.ScalarTypes.ScalarReply)
+
+      assert synth.name == real.name
+      assert comparable_fields(synth) == comparable_fields(real)
+    end
+
+    test "proto3_optional fields get synthetic oneof_index and oneof_decl" do
+      real = ScalarTypes.ScalarRequest.descriptor()
+      synth = Synthesizer.message_descriptor(NoDescriptor.ScalarTypes.ScalarRequest)
+
+      real_by_name = Map.new(real.field, &{&1.name, &1})
+      synth_by_name = Map.new(synth.field, &{&1.name, &1})
+
+      assert real_by_name["optional_string"].oneof_index ==
+               synth_by_name["optional_string"].oneof_index
+
+      assert real_by_name["optional_int"].oneof_index ==
+               synth_by_name["optional_int"].oneof_index
+
+      real_decl_names = Enum.map(real.oneof_decl, & &1.name)
+      synth_decl_names = Enum.map(synth.oneof_decl, & &1.name)
+      assert real_decl_names == synth_decl_names
+    end
+  end
+
+  describe "enum_descriptor/1 matches real descriptor" do
+    test "Status matches protoc output" do
+      real = Proto2Features.Status.descriptor()
+      synth = Synthesizer.enum_descriptor(NoDescriptor.Proto2Features.Status)
+
+      assert synth == real
+    end
+
+    test "DetailedStatus values and names match protoc output" do
+      real = EdgeCases.DetailedStatus.descriptor()
+      synth = Synthesizer.enum_descriptor(NoDescriptor.EdgeCases.DetailedStatus)
+
+      assert synth.name == real.name
+
+      # Values are sorted by number (runtime limitation — declaration order is not
+      # available without descriptor/0). Clients look up by number so this is safe.
+      real_by_number = Map.new(real.value, &{&1.number, &1.name})
+      synth_by_number = Map.new(synth.value, &{&1.number, &1.name})
+      assert synth_by_number == real_by_number
+
+      # Ordering is numeric, including negative values and max int32
+      assert Enum.map(synth.value, & &1.number) == Enum.sort(Enum.map(real.value, & &1.number))
+    end
+  end
+
+  describe "service_descriptor/1 matches real descriptor" do
+    test "Proto2Service matches protoc output" do
+      real = Synthesizer.service_descriptor(Proto2Features.Proto2Service.Service)
+      synth = Synthesizer.service_descriptor(NoDescriptor.Proto2Features.Proto2Service.Service)
+
+      assert synth == real
+    end
+
+    test "StreamingService matches protoc output" do
+      real = Synthesizer.service_descriptor(Streaming.StreamingService.Service)
+      synth = Synthesizer.service_descriptor(NoDescriptor.Streaming.StreamingService.Service)
+
+      assert synth == real
+    end
+  end
+end

--- a/test/service/builder/util_test.exs
+++ b/test/service/builder/util_test.exs
@@ -40,6 +40,13 @@ defmodule GrpcReflection.Service.Builder.UtilTest do
     end
   end
 
+  describe "validate_services/1 without descriptor/0" do
+    test "accepts a service module that has __rpc_calls__ but no descriptor/0" do
+      assert :ok =
+               Util.validate_services([NoDescriptor.ScalarTypes.ScalarService.Service])
+    end
+  end
+
   describe "utils for dealing with proto2 only" do
     test "convert %Google.Protobuf.FieldProps{} to %Google.Protobuf.FieldDescriptorProto{}" do
       extendee = Proto2Features.Proto2Request

--- a/test/service/builder_test.exs
+++ b/test/service/builder_test.exs
@@ -107,9 +107,7 @@ defmodule GrpcReflection.Service.BuilderTest do
   end
 
   test "handles a non-service module" do
-    assert_raise UndefinedFunctionError, fn ->
-      Builder.build_reflection_tree([Enum])
-    end
+    assert {:error, "non-service module provided"} = Builder.build_reflection_tree([Enum])
   end
 
   # protobuf_generate wraps service descriptors into FileDescriptors

--- a/test/support/client.ex
+++ b/test/support/client.ex
@@ -149,6 +149,23 @@ defmodule GrpcReflection.TestClient do
     end)
   end
 
+  # Makes a real gRPC call using reflection (no -proto flag). grpcurl fetches the
+  # descriptor from the server, encodes the JSON request into binary protobuf using
+  # that descriptor, sends it, and decodes the response. Asserts exit code 0 and
+  # returns the parsed JSON response map.
+  def grpcurl_call(%{host: host}, method, json_request) do
+    {result, 0} =
+      System.cmd("grpcurl", [
+        "-plaintext",
+        "-d",
+        Jason.encode!(json_request),
+        host,
+        method
+      ])
+
+    Jason.decode!(result)
+  end
+
   def grpcurl_service(ctx) do
     ctx
     |> grpcurl_list_services()

--- a/test/support/grpc_case.ex
+++ b/test/support/grpc_case.ex
@@ -3,6 +3,7 @@ defmodule GrpcCase do
 
   using opts do
     service = Keyword.get(opts, :service)
+    handler = Keyword.get(opts, :handler)
 
     quote do
       import GrpcCase
@@ -33,6 +34,7 @@ defmodule GrpcCase do
 
           run(V1Server)
           run(V1AlphaServer)
+          if unquote(handler), do: run(unquote(handler))
         end
 
         defp stub_v1_server(_) do

--- a/test/support/protos/deprecated_fields.pb.ex
+++ b/test/support/protos/deprecated_fields.pb.ex
@@ -1,0 +1,247 @@
+defmodule DeprecatedFields.DeprecatedRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "deprecated_fields.DeprecatedRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "DeprecatedRequest",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "active_field",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "activeField",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "legacy_field",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: true,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_index: nil,
+          json_name: "legacyField",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "active_id",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "activeId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "old_id",
+          extendee: nil,
+          number: 4,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: true,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_index: nil,
+          json_name: "oldId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :active_field, 1, type: :string, json_name: "activeField"
+  field :legacy_field, 2, type: :string, json_name: "legacyField", deprecated: true
+  field :active_id, 3, type: :int32, json_name: "activeId"
+  field :old_id, 4, type: :int32, json_name: "oldId", deprecated: true
+end
+
+defmodule DeprecatedFields.DeprecatedResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "deprecated_fields.DeprecatedResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "DeprecatedResponse",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "success",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BOOL,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "success",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "result",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "result",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "old_result",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: true,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_index: nil,
+          json_name: "oldResult",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :success, 1, type: :bool
+  field :result, 2, type: :string
+  field :old_result, 3, type: :string, json_name: "oldResult", deprecated: true
+end
+
+defmodule DeprecatedFields.DeprecatedFieldsService.Service do
+  @moduledoc false
+
+  use GRPC.Service,
+    name: "deprecated_fields.DeprecatedFieldsService",
+    protoc_gen_elixir_version: "0.16.0"
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.ServiceDescriptorProto{
+      name: "DeprecatedFieldsService",
+      method: [
+        %Google.Protobuf.MethodDescriptorProto{
+          name: "Process",
+          input_type: ".deprecated_fields.DeprecatedRequest",
+          output_type: ".deprecated_fields.DeprecatedResponse",
+          options: nil,
+          client_streaming: false,
+          server_streaming: false,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      __unknown_fields__: []
+    }
+  end
+
+  rpc :Process, DeprecatedFields.DeprecatedRequest, DeprecatedFields.DeprecatedResponse
+end
+
+defmodule DeprecatedFields.DeprecatedFieldsService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: DeprecatedFields.DeprecatedFieldsService.Service
+end

--- a/test/support/protos/no_descriptor/common_types.pb.ex
+++ b/test/support/protos/no_descriptor/common_types.pb.ex
@@ -1,0 +1,62 @@
+defmodule NoDescriptor.Common.Priority do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "common.Priority",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :PRIORITY_UNSPECIFIED, 0
+  field :LOW, 1
+  field :MEDIUM, 2
+  field :HIGH, 3
+  field :CRITICAL, 4
+end
+
+defmodule NoDescriptor.Common.Address do
+  @moduledoc false
+
+  use Protobuf, full_name: "common.Address", protoc_gen_elixir_version: "0.16.0", syntax: :proto3
+
+  field :street, 1, type: :string
+  field :city, 2, type: :string
+  field :state, 3, type: :string
+  field :postal_code, 4, type: :string, json_name: "postalCode"
+  field :country, 5, type: :string
+end
+
+defmodule NoDescriptor.Common.Coordinates do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "common.Coordinates",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :latitude, 1, type: :double
+  field :longitude, 2, type: :double
+  field :altitude, 3, type: :double
+end
+
+defmodule NoDescriptor.Common.Money do
+  @moduledoc false
+
+  use Protobuf, full_name: "common.Money", protoc_gen_elixir_version: "0.16.0", syntax: :proto3
+
+  field :currency_code, 1, type: :string, json_name: "currencyCode"
+  field :units, 2, type: :int64
+  field :nanos, 3, type: :int32
+end
+
+defmodule NoDescriptor.Common.TimeRange do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "common.TimeRange",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :start_time, 1, type: :int64, json_name: "startTime"
+  field :end_time, 2, type: :int64, json_name: "endTime"
+end

--- a/test/support/protos/no_descriptor/deprecated_fields.pb.ex
+++ b/test/support/protos/no_descriptor/deprecated_fields.pb.ex
@@ -1,0 +1,44 @@
+defmodule NoDescriptor.DeprecatedFields.DeprecatedRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "deprecated_fields.DeprecatedRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :active_field, 1, type: :string, json_name: "activeField"
+  field :legacy_field, 2, type: :string, json_name: "legacyField", deprecated: true
+  field :active_id, 3, type: :int32, json_name: "activeId"
+  field :old_id, 4, type: :int32, json_name: "oldId", deprecated: true
+end
+
+defmodule NoDescriptor.DeprecatedFields.DeprecatedResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "deprecated_fields.DeprecatedResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :success, 1, type: :bool
+  field :result, 2, type: :string
+  field :old_result, 3, type: :string, json_name: "oldResult", deprecated: true
+end
+
+defmodule NoDescriptor.DeprecatedFields.DeprecatedFieldsService.Service do
+  @moduledoc false
+
+  use GRPC.Service,
+    name: "deprecated_fields.DeprecatedFieldsService",
+    protoc_gen_elixir_version: "0.16.0"
+
+  rpc :Process,
+      NoDescriptor.DeprecatedFields.DeprecatedRequest,
+      NoDescriptor.DeprecatedFields.DeprecatedResponse
+end
+
+defmodule NoDescriptor.DeprecatedFields.DeprecatedFieldsService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.DeprecatedFields.DeprecatedFieldsService.Service
+end

--- a/test/support/protos/no_descriptor/edge_cases.pb.ex
+++ b/test/support/protos/no_descriptor/edge_cases.pb.ex
@@ -1,0 +1,392 @@
+defmodule NoDescriptor.EdgeCases.DetailedStatus do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "edge_cases.DetailedStatus",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :DETAILED_STATUS_UNSPECIFIED, 0
+  field :status_active, 1
+  field :STATUS_INACTIVE, 2
+  field :Status_Pending, 3
+  field :ERROR_STATE, -1
+  field :CRITICAL_ERROR, -100
+  field :MAX_STATUS, 2_147_483_647
+end
+
+defmodule NoDescriptor.EdgeCases.EmptyInputRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.EmptyInputRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+end
+
+defmodule NoDescriptor.EdgeCases.EmptyInputResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.EmptyInputResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :data, 1, type: :string
+end
+
+defmodule NoDescriptor.EdgeCases.EmptyOutputRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.EmptyOutputRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :data, 1, type: :string
+end
+
+defmodule NoDescriptor.EdgeCases.EmptyOutputResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.EmptyOutputResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+end
+
+defmodule NoDescriptor.EdgeCases.BothEmptyRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.BothEmptyRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+end
+
+defmodule NoDescriptor.EdgeCases.BothEmptyResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.BothEmptyResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+end
+
+defmodule NoDescriptor.EdgeCases.ComplicatedRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.ComplicatedRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :numbers, 1, type: NoDescriptor.EdgeCases.SparseFieldNumbers
+  field :fields, 2, type: NoDescriptor.EdgeCases.ManyFields
+  field :status, 3, type: NoDescriptor.EdgeCases.DetailedStatus, enum: true
+  field :oneofs, 4, type: NoDescriptor.EdgeCases.MultipleOneofs
+  field :nested_maps, 5, type: NoDescriptor.EdgeCases.NestedMaps, json_name: "nestedMaps"
+  field :circular, 6, type: NoDescriptor.EdgeCases.CircularA
+
+  field :reserved_fields, 7,
+    type: NoDescriptor.EdgeCases.WithReservedFields,
+    json_name: "reservedFields"
+
+  field :unicode_test, 8, type: NoDescriptor.EdgeCases.UnicodeTest, json_name: "unicodeTest"
+end
+
+defmodule NoDescriptor.EdgeCases.ComplicatedResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.ComplicatedResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :numbers, 1, type: NoDescriptor.EdgeCases.SparseFieldNumbers
+  field :fields, 2, type: NoDescriptor.EdgeCases.ManyFields
+  field :status, 3, type: NoDescriptor.EdgeCases.DetailedStatus, enum: true
+  field :oneofs, 4, type: NoDescriptor.EdgeCases.MultipleOneofs
+  field :nested_maps, 5, type: NoDescriptor.EdgeCases.NestedMaps, json_name: "nestedMaps"
+  field :circular, 6, type: NoDescriptor.EdgeCases.CircularA
+
+  field :reserved_fields, 7,
+    type: NoDescriptor.EdgeCases.WithReservedFields,
+    json_name: "reservedFields"
+
+  field :unicode_test, 8, type: NoDescriptor.EdgeCases.UnicodeTest, json_name: "unicodeTest"
+end
+
+defmodule NoDescriptor.EdgeCases.SparseFieldNumbers do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.SparseFieldNumbers",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :field_1, 1, type: :string, json_name: "field1"
+  field :field_536870911, 536_870_911, type: :string, json_name: "field536870911"
+end
+
+defmodule NoDescriptor.EdgeCases.ManyFields do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.ManyFields",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :field_001, 1, type: :string, json_name: "field001"
+  field :field_002, 2, type: :string, json_name: "field002"
+  field :field_003, 3, type: :string, json_name: "field003"
+  field :field_004, 4, type: :string, json_name: "field004"
+  field :field_005, 5, type: :string, json_name: "field005"
+  field :field_006, 6, type: :string, json_name: "field006"
+  field :field_007, 7, type: :string, json_name: "field007"
+  field :field_008, 8, type: :string, json_name: "field008"
+  field :field_009, 9, type: :string, json_name: "field009"
+  field :field_010, 10, type: :string, json_name: "field010"
+  field :field_011, 11, type: :string, json_name: "field011"
+  field :field_012, 12, type: :string, json_name: "field012"
+  field :field_013, 13, type: :string, json_name: "field013"
+  field :field_014, 14, type: :string, json_name: "field014"
+  field :field_015, 15, type: :string, json_name: "field015"
+  field :field_016, 16, type: :string, json_name: "field016"
+  field :field_017, 17, type: :string, json_name: "field017"
+  field :field_018, 18, type: :string, json_name: "field018"
+  field :field_019, 19, type: :string, json_name: "field019"
+  field :field_020, 20, type: :string, json_name: "field020"
+end
+
+defmodule NoDescriptor.EdgeCases.MultipleOneofs do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.MultipleOneofs",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  oneof :first_choice, 0
+
+  oneof :second_choice, 1
+
+  oneof :third_choice, 2
+
+  field :option_a1, 1, type: :string, json_name: "optionA1", oneof: 0
+  field :option_a2, 2, type: :int32, json_name: "optionA2", oneof: 0
+  field :option_b1, 3, type: :string, json_name: "optionB1", oneof: 1
+  field :option_b2, 4, type: :int32, json_name: "optionB2", oneof: 1
+  field :option_c1, 5, type: :string, json_name: "optionC1", oneof: 2
+  field :option_c2, 6, type: :int32, json_name: "optionC2", oneof: 2
+  field :regular_field, 7, type: :string, json_name: "regularField"
+end
+
+defmodule NoDescriptor.EdgeCases.NestedMaps.OuterMapEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.NestedMaps.OuterMapEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :string
+  field :value, 2, type: NoDescriptor.EdgeCases.InnerMap
+end
+
+defmodule NoDescriptor.EdgeCases.NestedMaps.IntKeyMapEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.NestedMaps.IntKeyMapEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :int32
+  field :value, 2, type: :string
+end
+
+defmodule NoDescriptor.EdgeCases.NestedMaps.NumericMapEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.NestedMaps.NumericMapEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :int64
+  field :value, 2, type: :int64
+end
+
+defmodule NoDescriptor.EdgeCases.NestedMaps.BoolKeyMapEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.NestedMaps.BoolKeyMapEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :bool
+  field :value, 2, type: :string
+end
+
+defmodule NoDescriptor.EdgeCases.NestedMaps do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.NestedMaps",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :outer_map, 1,
+    repeated: true,
+    type: NoDescriptor.EdgeCases.NestedMaps.OuterMapEntry,
+    json_name: "outerMap",
+    map: true
+
+  field :int_key_map, 2,
+    repeated: true,
+    type: NoDescriptor.EdgeCases.NestedMaps.IntKeyMapEntry,
+    json_name: "intKeyMap",
+    map: true
+
+  field :numeric_map, 3,
+    repeated: true,
+    type: NoDescriptor.EdgeCases.NestedMaps.NumericMapEntry,
+    json_name: "numericMap",
+    map: true
+
+  field :bool_key_map, 4,
+    repeated: true,
+    type: NoDescriptor.EdgeCases.NestedMaps.BoolKeyMapEntry,
+    json_name: "boolKeyMap",
+    map: true
+end
+
+defmodule NoDescriptor.EdgeCases.InnerMap.DataEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.InnerMap.DataEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :string
+  field :value, 2, type: :string
+end
+
+defmodule NoDescriptor.EdgeCases.InnerMap.CountsEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.InnerMap.CountsEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :string
+  field :value, 2, type: :int32
+end
+
+defmodule NoDescriptor.EdgeCases.InnerMap do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.InnerMap",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :data, 1, repeated: true, type: NoDescriptor.EdgeCases.InnerMap.DataEntry, map: true
+  field :counts, 2, repeated: true, type: NoDescriptor.EdgeCases.InnerMap.CountsEntry, map: true
+end
+
+defmodule NoDescriptor.EdgeCases.CircularA do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.CircularA",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :b_field, 1, type: NoDescriptor.EdgeCases.CircularB, json_name: "bField"
+  field :data, 2, type: :string
+end
+
+defmodule NoDescriptor.EdgeCases.CircularB do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.CircularB",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :c_field, 1, type: NoDescriptor.EdgeCases.CircularC, json_name: "cField"
+  field :data, 2, type: :string
+end
+
+defmodule NoDescriptor.EdgeCases.CircularC do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.CircularC",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :a_field, 1, type: NoDescriptor.EdgeCases.CircularA, json_name: "aField"
+  field :data, 2, type: :string
+end
+
+defmodule NoDescriptor.EdgeCases.WithReservedFields do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.WithReservedFields",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :active_field_1, 1, type: :string, json_name: "activeField1"
+  field :active_field_16, 16, type: :string, json_name: "activeField16"
+end
+
+defmodule NoDescriptor.EdgeCases.UnicodeTest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "edge_cases.UnicodeTest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :rocket_field, 1, type: :string, json_name: "rocketField"
+  field :pi_field, 2, type: :double, json_name: "piField"
+  field :greeting, 3, type: :string
+end
+
+defmodule NoDescriptor.EdgeCases.EdgeCaseService.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "edge_cases.EdgeCaseService", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :EmptyInput,
+      NoDescriptor.EdgeCases.EmptyInputRequest,
+      NoDescriptor.EdgeCases.EmptyInputResponse
+
+  rpc :EmptyOutput,
+      NoDescriptor.EdgeCases.EmptyOutputRequest,
+      NoDescriptor.EdgeCases.EmptyOutputResponse
+
+  rpc :BothEmpty,
+      NoDescriptor.EdgeCases.BothEmptyRequest,
+      NoDescriptor.EdgeCases.BothEmptyResponse
+end
+
+defmodule NoDescriptor.EdgeCases.EdgeCaseService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.EdgeCases.EdgeCaseService.Service
+end

--- a/test/support/protos/no_descriptor/empty_service.pb.ex
+++ b/test/support/protos/no_descriptor/empty_service.pb.ex
@@ -1,0 +1,11 @@
+defmodule NoDescriptor.EmptyService.EmptyService.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "empty_service.EmptyService", protoc_gen_elixir_version: "0.16.0"
+end
+
+defmodule NoDescriptor.EmptyService.EmptyService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.EmptyService.EmptyService.Service
+end

--- a/test/support/protos/no_descriptor/global_service.pb.ex
+++ b/test/support/protos/no_descriptor/global_service.pb.ex
@@ -1,0 +1,29 @@
+defmodule NoDescriptor.GlobalRequest do
+  @moduledoc false
+
+  use Protobuf, full_name: "GlobalRequest", protoc_gen_elixir_version: "0.16.0", syntax: :proto3
+
+  field :data, 1, type: :string
+end
+
+defmodule NoDescriptor.GlobalResponse do
+  @moduledoc false
+
+  use Protobuf, full_name: "GlobalResponse", protoc_gen_elixir_version: "0.16.0", syntax: :proto3
+
+  field :result, 1, type: :string
+end
+
+defmodule NoDescriptor.GlobalService.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "GlobalService", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :GlobalMethod, NoDescriptor.GlobalRequest, NoDescriptor.GlobalResponse
+end
+
+defmodule NoDescriptor.GlobalService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.GlobalService.Service
+end

--- a/test/support/protos/no_descriptor/imports_test.pb.ex
+++ b/test/support/protos/no_descriptor/imports_test.pb.ex
@@ -1,0 +1,138 @@
+defmodule NoDescriptor.ImportsTest.UserRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "imports_test.UserRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :name, 1, type: :string
+  field :email, 2, type: :string
+  field :address, 3, type: Common.Address
+  field :location, 4, type: Common.Coordinates
+  field :registered_at, 5, type: Google.Protobuf.Timestamp, json_name: "registeredAt"
+end
+
+defmodule NoDescriptor.ImportsTest.UserResponse.Profile do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "imports_test.UserResponse.Profile",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :billing_address, 1, type: Common.Address, json_name: "billingAddress"
+  field :shipping_address, 2, type: Common.Address, json_name: "shippingAddress"
+
+  field :recent_locations, 3,
+    repeated: true,
+    type: Common.Coordinates,
+    json_name: "recentLocations"
+end
+
+defmodule NoDescriptor.ImportsTest.UserResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "imports_test.UserResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :priority, 2, type: Common.Priority, enum: true
+  field :created_at, 3, type: Google.Protobuf.Timestamp, json_name: "createdAt"
+  field :profile, 4, type: NoDescriptor.ImportsTest.UserResponse.Profile
+end
+
+defmodule NoDescriptor.ImportsTest.LocationUpdate do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "imports_test.LocationUpdate",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :new_location, 2, type: Common.Coordinates, json_name: "newLocation"
+  field :timestamp, 3, type: Google.Protobuf.Timestamp
+end
+
+defmodule NoDescriptor.ImportsTest.LocationResponse.VisitHistoryEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "imports_test.LocationResponse.VisitHistoryEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :string
+  field :value, 2, type: Common.TimeRange
+end
+
+defmodule NoDescriptor.ImportsTest.LocationResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "imports_test.LocationResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :success, 1, type: :bool
+  field :confirmed_location, 2, type: Common.Coordinates, json_name: "confirmedLocation"
+
+  field :visit_history, 3,
+    repeated: true,
+    type: NoDescriptor.ImportsTest.LocationResponse.VisitHistoryEntry,
+    json_name: "visitHistory",
+    map: true
+end
+
+defmodule NoDescriptor.ImportsTest.BulkOperation.TaskPrioritiesEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "imports_test.BulkOperation.TaskPrioritiesEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :string
+  field :value, 2, type: Common.Priority, enum: true
+end
+
+defmodule NoDescriptor.ImportsTest.BulkOperation do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "imports_test.BulkOperation",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :addresses, 1, repeated: true, type: Common.Address
+  field :transactions, 2, repeated: true, type: Common.Money
+
+  field :task_priorities, 3,
+    repeated: true,
+    type: NoDescriptor.ImportsTest.BulkOperation.TaskPrioritiesEntry,
+    json_name: "taskPriorities",
+    map: true
+end
+
+defmodule NoDescriptor.ImportsTest.ImportTestService.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "imports_test.ImportTestService", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :CreateUser, NoDescriptor.ImportsTest.UserRequest, NoDescriptor.ImportsTest.UserResponse
+
+  rpc :UpdateLocation,
+      NoDescriptor.ImportsTest.LocationUpdate,
+      NoDescriptor.ImportsTest.LocationResponse
+end
+
+defmodule NoDescriptor.ImportsTest.ImportTestService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.ImportsTest.ImportTestService.Service
+end

--- a/test/support/protos/no_descriptor/nested_enum_conflict.pb.ex
+++ b/test/support/protos/no_descriptor/nested_enum_conflict.pb.ex
@@ -1,0 +1,95 @@
+defmodule NoDescriptor.NestedEnumConflict.ListFoosRequest.SortOrder do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "nestedEnumConflict.ListFoosRequest.SortOrder",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :SORT_ORDER_UNSPECIFIED, 0
+  field :SORT_ORDER_NEWEST_FIRST, 1
+  field :SORT_ORDER_OLDEST_FIRST, 2
+end
+
+defmodule NoDescriptor.NestedEnumConflict.ListBarsRequest.SortOrder do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "nestedEnumConflict.ListBarsRequest.SortOrder",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :SORT_ORDER_UNSPECIFIED, 0
+  field :SORT_ORDER_NEWEST_FIRST, 1
+  field :SORT_ORDER_OLDEST_FIRST, 2
+end
+
+defmodule NoDescriptor.NestedEnumConflict.ListFoosRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nestedEnumConflict.ListFoosRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :sort_order, 1,
+    type: NoDescriptor.NestedEnumConflict.ListFoosRequest.SortOrder,
+    json_name: "sortOrder",
+    enum: true
+end
+
+defmodule NoDescriptor.NestedEnumConflict.ListFoosResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nestedEnumConflict.ListFoosResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+end
+
+defmodule NoDescriptor.NestedEnumConflict.ListBarsRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nestedEnumConflict.ListBarsRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :sort_order, 1,
+    type: NoDescriptor.NestedEnumConflict.ListBarsRequest.SortOrder,
+    json_name: "sortOrder",
+    enum: true
+end
+
+defmodule NoDescriptor.NestedEnumConflict.ListBarsResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nestedEnumConflict.ListBarsResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+end
+
+defmodule NoDescriptor.NestedEnumConflict.ConflictService.Service do
+  @moduledoc false
+
+  use GRPC.Service,
+    name: "nestedEnumConflict.ConflictService",
+    protoc_gen_elixir_version: "0.16.0"
+
+  rpc :ListFoos,
+      NoDescriptor.NestedEnumConflict.ListFoosRequest,
+      NoDescriptor.NestedEnumConflict.ListFoosResponse
+
+  rpc :ListBars,
+      NoDescriptor.NestedEnumConflict.ListBarsRequest,
+      NoDescriptor.NestedEnumConflict.ListBarsResponse
+end
+
+defmodule NoDescriptor.NestedEnumConflict.ConflictService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.NestedEnumConflict.ConflictService.Service
+end

--- a/test/support/protos/no_descriptor/nested_messages.pb.ex
+++ b/test/support/protos/no_descriptor/nested_messages.pb.ex
@@ -1,0 +1,237 @@
+defmodule NoDescriptor.Nested.ComplexNested.Status do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "nested.ComplexNested.Status",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :UNKNOWN, 0
+  field :ACTIVE, 1
+  field :INACTIVE, 2
+end
+
+defmodule NoDescriptor.Nested.ComplexNested.Node.NodeType do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "nested.ComplexNested.Node.NodeType",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :LEAF, 0
+  field :BRANCH, 1
+  field :ROOT, 2
+end
+
+defmodule NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage.DeepMessage.VeryDeepMessage do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.OuterMessage.MiddleMessage.InnerMessage.DeepMessage.VeryDeepMessage",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :very_deep_field, 1, type: :string, json_name: "veryDeepField"
+  field :values, 2, repeated: true, type: :int32
+end
+
+defmodule NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage.DeepMessage do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.OuterMessage.MiddleMessage.InnerMessage.DeepMessage",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :deep_field, 1, type: :string, json_name: "deepField"
+
+  field :very_deep, 2,
+    type: NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage.DeepMessage.VeryDeepMessage,
+    json_name: "veryDeep"
+end
+
+defmodule NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.OuterMessage.MiddleMessage.InnerMessage",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :inner_field, 1, type: :string, json_name: "innerField"
+  field :deep, 2, type: NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage.DeepMessage
+end
+
+defmodule NoDescriptor.Nested.OuterMessage.MiddleMessage do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.OuterMessage.MiddleMessage",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :middle_field, 1, type: :string, json_name: "middleField"
+  field :inner, 2, type: NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage
+
+  field :inner_list, 3,
+    repeated: true,
+    type: NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage,
+    json_name: "innerList"
+end
+
+defmodule NoDescriptor.Nested.OuterMessage.NestedMapEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.OuterMessage.NestedMapEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :string
+  field :value, 2, type: NoDescriptor.Nested.OuterMessage.MiddleMessage
+end
+
+defmodule NoDescriptor.Nested.OuterMessage do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.OuterMessage",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  oneof :nested_oneof, 0
+
+  field :outer_field, 1, type: :string, json_name: "outerField"
+  field :middle, 2, type: NoDescriptor.Nested.OuterMessage.MiddleMessage
+
+  field :middle_list, 3,
+    repeated: true,
+    type: NoDescriptor.Nested.OuterMessage.MiddleMessage,
+    json_name: "middleList"
+
+  field :nested_map, 4,
+    repeated: true,
+    type: NoDescriptor.Nested.OuterMessage.NestedMapEntry,
+    json_name: "nestedMap",
+    map: true
+
+  field :option_a, 5,
+    type: NoDescriptor.Nested.OuterMessage.MiddleMessage,
+    json_name: "optionA",
+    oneof: 0
+
+  field :option_b, 6,
+    type: NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage,
+    json_name: "optionB",
+    oneof: 0
+
+  field :simple_option, 7, type: :string, json_name: "simpleOption", oneof: 0
+end
+
+defmodule NoDescriptor.Nested.OuterResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.OuterResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :deep_result, 1,
+    type: NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage.DeepMessage,
+    json_name: "deepResult"
+
+  field :middle_results, 2,
+    repeated: true,
+    type: NoDescriptor.Nested.OuterMessage.MiddleMessage,
+    json_name: "middleResults"
+end
+
+defmodule NoDescriptor.Nested.ComplexNested.Node.NamedChildrenEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.ComplexNested.Node.NamedChildrenEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :key, 1, type: :string
+  field :value, 2, type: NoDescriptor.Nested.ComplexNested.Node
+end
+
+defmodule NoDescriptor.Nested.ComplexNested.Node do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.ComplexNested.Node",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :id, 1, type: :string
+  field :type, 2, type: NoDescriptor.Nested.ComplexNested.Node.NodeType, enum: true
+  field :children, 3, repeated: true, type: NoDescriptor.Nested.ComplexNested.Node
+  field :parent, 4, type: NoDescriptor.Nested.ComplexNested.Node
+
+  field :named_children, 5,
+    repeated: true,
+    type: NoDescriptor.Nested.ComplexNested.Node.NamedChildrenEntry,
+    json_name: "namedChildren",
+    map: true
+end
+
+defmodule NoDescriptor.Nested.ComplexNested do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "nested.ComplexNested",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :status, 1, type: NoDescriptor.Nested.ComplexNested.Status, enum: true
+  field :root, 2, type: NoDescriptor.Nested.ComplexNested.Node
+
+  field :all_nodes, 3,
+    repeated: true,
+    type: NoDescriptor.Nested.ComplexNested.Node,
+    json_name: "allNodes"
+end
+
+defmodule NoDescriptor.Nested.NestedService.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "nested.NestedService", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :ProcessNested, NoDescriptor.Nested.OuterMessage, NoDescriptor.Nested.OuterResponse
+end
+
+defmodule NoDescriptor.Nested.NestedService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.Nested.NestedService.Service
+end
+
+defmodule NoDescriptor.Nested.AnotherNestedService.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "nested.AnotherNestedService", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :ProcessOuter, NoDescriptor.Nested.OuterMessage, NoDescriptor.Nested.OuterResponse
+
+  rpc :ProcessMiddle,
+      NoDescriptor.Nested.OuterMessage.MiddleMessage,
+      NoDescriptor.Nested.OuterMessage.MiddleMessage
+
+  rpc :ProcessInner,
+      NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage,
+      NoDescriptor.Nested.OuterMessage.MiddleMessage.InnerMessage
+end
+
+defmodule NoDescriptor.Nested.AnotherNestedService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.Nested.AnotherNestedService.Service
+end

--- a/test/support/protos/no_descriptor/no_descriptor/proto2_features/pb_extension.pb.ex
+++ b/test/support/protos/no_descriptor/no_descriptor/proto2_features/pb_extension.pb.ex
@@ -1,0 +1,41 @@
+defmodule NoDescriptor.Proto2Features.PbExtension do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.16.0"
+
+  extend NoDescriptor.Proto2Features.Proto2Request, :extended_field, 100,
+    optional: true,
+    type: :string,
+    json_name: "extendedField"
+
+  extend NoDescriptor.Proto2Features.Proto2Request, :extended_timestamp, 101,
+    optional: true,
+    type: :int64,
+    json_name: "extendedTimestamp"
+
+  extend NoDescriptor.Proto2Features.Proto2Request, :extension_data, 102,
+    optional: true,
+    type: NoDescriptor.Proto2Features.ExtensionData,
+    json_name: "extensionData"
+
+  extend NoDescriptor.Proto2Features.Proto2Request, :timestamp_extension, 103,
+    optional: true,
+    type: Google.Protobuf.Timestamp,
+    json_name: "timestampExtension"
+
+  extend NoDescriptor.Proto2Features.ExtendableMessage, :meta_info, 1000,
+    optional: true,
+    type: :string,
+    json_name: "metaInfo"
+
+  extend NoDescriptor.Proto2Features.ExtendableMessage, :nested_extension, 1001,
+    optional: true,
+    type: NoDescriptor.Proto2Features.ExtendableMessage.NestedInExtendable,
+    json_name: "nestedExtension"
+
+  extend NoDescriptor.Proto2Features.ExtendableMessage, :enum_extension, 1002,
+    optional: true,
+    type: NoDescriptor.Proto2Features.ExtendableMessage.ExtendableEnum,
+    json_name: "enumExtension",
+    enum: true
+end

--- a/test/support/protos/no_descriptor/package_a.pb.ex
+++ b/test/support/protos/no_descriptor/package_a.pb.ex
@@ -1,0 +1,25 @@
+defmodule NoDescriptor.PackageA.EnumA do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "package_a.EnumA",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :ENUM_A_UNSPECIFIED, 0
+  field :OPTION_1, 1
+  field :OPTION_2, 2
+end
+
+defmodule NoDescriptor.PackageA.MessageA do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "package_a.MessageA",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :field_a, 1, type: :string, json_name: "fieldA"
+  field :count, 2, type: :int32
+end

--- a/test/support/protos/no_descriptor/package_b.pb.ex
+++ b/test/support/protos/no_descriptor/package_b.pb.ex
@@ -1,0 +1,39 @@
+defmodule NoDescriptor.PackageB.MessageB do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "package_b.MessageB",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :field_b, 1, type: :string, json_name: "fieldB"
+  field :message_from_a, 2, type: PackageA.MessageA, json_name: "messageFromA"
+  field :enum_from_a, 3, type: PackageA.EnumA, json_name: "enumFromA", enum: true
+end
+
+defmodule NoDescriptor.PackageB.ResponseB do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "package_b.ResponseB",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :results, 1, repeated: true, type: PackageA.MessageA
+end
+
+defmodule NoDescriptor.PackageB.ServiceB.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "package_b.ServiceB", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :ProcessB, NoDescriptor.PackageB.MessageB, NoDescriptor.PackageB.ResponseB
+
+  rpc :ProcessA, PackageA.MessageA, PackageA.MessageA
+end
+
+defmodule NoDescriptor.PackageB.ServiceB.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.PackageB.ServiceB.Service
+end

--- a/test/support/protos/no_descriptor/proto2_features.pb.ex
+++ b/test/support/protos/no_descriptor/proto2_features.pb.ex
@@ -1,0 +1,141 @@
+defmodule NoDescriptor.Proto2Features.Status do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "proto2_features.Status",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto2
+
+  field :UNKNOWN, 0
+  field :ACTIVE, 1
+  field :INACTIVE, 2
+end
+
+defmodule NoDescriptor.Proto2Features.ExtendableMessage.ExtendableEnum do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "proto2_features.ExtendableMessage.ExtendableEnum",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto2
+
+  field :OPTION_A, 0
+  field :OPTION_B, 1
+end
+
+defmodule NoDescriptor.Proto2Features.Proto2Request.MetadataMapEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "proto2_features.Proto2Request.MetadataMapEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto2
+
+  field :key, 1, optional: true, type: :string
+  field :value, 2, optional: true, type: :int32
+end
+
+defmodule NoDescriptor.Proto2Features.Proto2Request do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "proto2_features.Proto2Request",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto2
+
+  oneof :proto2_oneof, 0
+
+  field :required_field, 1, required: true, type: :string, json_name: "requiredField"
+  field :required_id, 2, required: true, type: :int32, json_name: "requiredId"
+  field :optional_field, 3, optional: true, type: :string, json_name: "optionalField"
+  field :optional_id, 4, optional: true, type: :int32, json_name: "optionalId"
+  field :name, 5, optional: true, type: :string, default: "unknown"
+  field :port, 6, optional: true, type: :int32, default: 8080
+  field :enabled, 7, optional: true, type: :bool, default: true
+
+  field :status, 8,
+    optional: true,
+    type: NoDescriptor.Proto2Features.Status,
+    default: :ACTIVE,
+    enum: true
+
+  field :oneof_string, 9, optional: true, type: :string, json_name: "oneofString", oneof: 0
+  field :oneof_int, 13, optional: true, type: :int32, json_name: "oneofInt", oneof: 0
+
+  field :metadata_map, 14,
+    repeated: true,
+    type: NoDescriptor.Proto2Features.Proto2Request.MetadataMapEntry,
+    json_name: "metadataMap",
+    map: true
+
+  field :any_values, 15, repeated: true, type: Google.Protobuf.Any, json_name: "anyValues"
+
+  extensions [{100, 200}]
+end
+
+defmodule NoDescriptor.Proto2Features.ExtensionData do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "proto2_features.ExtensionData",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto2
+
+  field :key, 1, optional: true, type: :string
+  field :value, 2, optional: true, type: :string
+end
+
+defmodule NoDescriptor.Proto2Features.Proto2Response do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "proto2_features.Proto2Response",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto2
+
+  field :success, 1, required: true, type: :bool
+  field :message, 2, optional: true, type: :string
+end
+
+defmodule NoDescriptor.Proto2Features.ExtendableMessage.NestedInExtendable do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "proto2_features.ExtendableMessage.NestedInExtendable",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto2
+
+  field :data, 1, optional: true, type: :string
+end
+
+defmodule NoDescriptor.Proto2Features.ExtendableMessage do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "proto2_features.ExtendableMessage",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto2
+
+  field :id, 1, required: true, type: :string
+
+  extensions [{1000, Protobuf.Extension.max()}]
+end
+
+defmodule NoDescriptor.Proto2Features.Proto2Service.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "proto2_features.Proto2Service", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :ProcessProto2,
+      NoDescriptor.Proto2Features.Proto2Request,
+      NoDescriptor.Proto2Features.Proto2Response
+end
+
+defmodule NoDescriptor.Proto2Features.Proto2Service.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.Proto2Features.Proto2Service.Service
+end

--- a/test/support/protos/no_descriptor/proto2_features.pb.ex
+++ b/test/support/protos/no_descriptor/proto2_features.pb.ex
@@ -73,6 +73,13 @@ defmodule NoDescriptor.Proto2Features.Proto2Request do
 
   field :any_values, 15, repeated: true, type: Google.Protobuf.Any, json_name: "anyValues"
 
+  field :packed_ints, 16,
+    repeated: true,
+    type: :int32,
+    json_name: "packedInts",
+    packed: true,
+    deprecated: false
+
   extensions [{100, 200}]
 end
 

--- a/test/support/protos/no_descriptor/recursive_message.pb.ex
+++ b/test/support/protos/no_descriptor/recursive_message.pb.ex
@@ -1,0 +1,35 @@
+defmodule NoDescriptor.RecursiveMessage.Request do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "recursive_message.Request",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :reply, 1, type: NoDescriptor.RecursiveMessage.Reply
+end
+
+defmodule NoDescriptor.RecursiveMessage.Reply do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "recursive_message.Reply",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :request, 1, type: NoDescriptor.RecursiveMessage.Request
+end
+
+defmodule NoDescriptor.RecursiveMessage.Service.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "recursive_message.Service", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :call, NoDescriptor.RecursiveMessage.Request, NoDescriptor.RecursiveMessage.Reply
+end
+
+defmodule NoDescriptor.RecursiveMessage.Service.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.RecursiveMessage.Service.Service
+end

--- a/test/support/protos/no_descriptor/scalar_types.pb.ex
+++ b/test/support/protos/no_descriptor/scalar_types.pb.ex
@@ -1,0 +1,70 @@
+defmodule NoDescriptor.ScalarTypes.ScalarRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "scalar_types.ScalarRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :double_field, 1, type: :double, json_name: "doubleField"
+  field :float_field, 2, type: :float, json_name: "floatField"
+  field :int32_field, 3, type: :int32, json_name: "int32Field"
+  field :int64_field, 4, type: :int64, json_name: "int64Field"
+  field :uint32_field, 5, type: :uint32, json_name: "uint32Field"
+  field :uint64_field, 6, type: :uint64, json_name: "uint64Field"
+  field :sint32_field, 7, type: :sint32, json_name: "sint32Field"
+  field :sint64_field, 8, type: :sint64, json_name: "sint64Field"
+  field :fixed32_field, 9, type: :fixed32, json_name: "fixed32Field"
+  field :fixed64_field, 10, type: :fixed64, json_name: "fixed64Field"
+  field :sfixed32_field, 11, type: :sfixed32, json_name: "sfixed32Field"
+  field :sfixed64_field, 12, type: :sfixed64, json_name: "sfixed64Field"
+  field :bool_field, 13, type: :bool, json_name: "boolField"
+  field :string_field, 14, type: :string, json_name: "stringField"
+  field :bytes_field, 15, type: :bytes, json_name: "bytesField"
+  field :optional_string, 18, proto3_optional: true, type: :string, json_name: "optionalString"
+  field :optional_int, 19, proto3_optional: true, type: :int32, json_name: "optionalInt"
+  field :sparse_field_1, 100, type: :string, json_name: "sparseField1"
+  field :sparse_field_2, 1000, type: :string, json_name: "sparseField2"
+  field :sparse_field_3, 10000, type: :string, json_name: "sparseField3"
+end
+
+defmodule NoDescriptor.ScalarTypes.ScalarReply do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "scalar_types.ScalarReply",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :double_list, 1, repeated: true, type: :double, json_name: "doubleList"
+  field :float_list, 2, repeated: true, type: :float, json_name: "floatList"
+  field :int32_list, 3, repeated: true, type: :int32, json_name: "int32List"
+  field :int64_list, 4, repeated: true, type: :int64, json_name: "int64List"
+  field :uint32_list, 5, repeated: true, type: :uint32, json_name: "uint32List"
+  field :uint64_list, 6, repeated: true, type: :uint64, json_name: "uint64List"
+  field :sint32_list, 7, repeated: true, type: :sint32, json_name: "sint32List"
+  field :sint64_list, 8, repeated: true, type: :sint64, json_name: "sint64List"
+  field :fixed32_list, 9, repeated: true, type: :fixed32, json_name: "fixed32List"
+  field :fixed64_list, 10, repeated: true, type: :fixed64, json_name: "fixed64List"
+  field :sfixed32_list, 11, repeated: true, type: :sfixed32, json_name: "sfixed32List"
+  field :sfixed64_list, 12, repeated: true, type: :sfixed64, json_name: "sfixed64List"
+  field :bool_list, 13, repeated: true, type: :bool, json_name: "boolList"
+  field :string_list, 14, repeated: true, type: :string, json_name: "stringList"
+  field :bytes_list, 15, repeated: true, type: :bytes, json_name: "bytesList"
+end
+
+defmodule NoDescriptor.ScalarTypes.ScalarService.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "scalar_types.ScalarService", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :ProcessScalars,
+      NoDescriptor.ScalarTypes.ScalarRequest,
+      NoDescriptor.ScalarTypes.ScalarReply
+end
+
+defmodule NoDescriptor.ScalarTypes.ScalarService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.ScalarTypes.ScalarService.Service
+end

--- a/test/support/protos/no_descriptor/streaming_service.pb.ex
+++ b/test/support/protos/no_descriptor/streaming_service.pb.ex
@@ -1,0 +1,111 @@
+defmodule NoDescriptor.Streaming.StreamRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "streaming.StreamRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :message, 1, type: :string
+  field :sequence, 2, type: :int32
+end
+
+defmodule NoDescriptor.Streaming.StreamResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "streaming.StreamResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :result, 1, type: :string
+  field :sequence, 2, type: :int32
+  field :is_final, 3, type: :bool, json_name: "isFinal"
+end
+
+defmodule NoDescriptor.Streaming.DataChunk do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "streaming.DataChunk",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :data, 1, type: :bytes
+  field :offset, 2, type: :int64
+  field :size, 3, type: :int32
+end
+
+defmodule NoDescriptor.Streaming.UploadStatus do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "streaming.UploadStatus",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :success, 1, type: :bool
+  field :total_bytes, 2, type: :int64, json_name: "totalBytes"
+  field :checksum, 3, type: :string
+end
+
+defmodule NoDescriptor.Streaming.DownloadRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "streaming.DownloadRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :file_id, 1, type: :string, json_name: "fileId"
+  field :start_offset, 2, type: :int64, json_name: "startOffset"
+  field :max_bytes, 3, type: :int64, json_name: "maxBytes"
+end
+
+defmodule NoDescriptor.Streaming.StreamingService.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "streaming.StreamingService", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :UnaryCall, NoDescriptor.Streaming.StreamRequest, NoDescriptor.Streaming.StreamResponse
+
+  rpc :ServerStreamingCall,
+      NoDescriptor.Streaming.StreamRequest,
+      stream(NoDescriptor.Streaming.StreamResponse)
+
+  rpc :ClientStreamingCall,
+      stream(NoDescriptor.Streaming.StreamRequest),
+      NoDescriptor.Streaming.StreamResponse
+
+  rpc :BidirectionalStreamingCall,
+      stream(NoDescriptor.Streaming.StreamRequest),
+      stream(NoDescriptor.Streaming.StreamResponse)
+end
+
+defmodule NoDescriptor.Streaming.StreamingService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.Streaming.StreamingService.Service
+end
+
+defmodule NoDescriptor.Streaming.MultiStreamService.Service do
+  @moduledoc false
+
+  use GRPC.Service, name: "streaming.MultiStreamService", protoc_gen_elixir_version: "0.16.0"
+
+  rpc :UploadData, stream(NoDescriptor.Streaming.DataChunk), NoDescriptor.Streaming.UploadStatus
+
+  rpc :DownloadData,
+      NoDescriptor.Streaming.DownloadRequest,
+      stream(NoDescriptor.Streaming.DataChunk)
+
+  rpc :SyncData,
+      stream(NoDescriptor.Streaming.DataChunk),
+      stream(NoDescriptor.Streaming.DataChunk)
+end
+
+defmodule NoDescriptor.Streaming.MultiStreamService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.Streaming.MultiStreamService.Service
+end

--- a/test/support/protos/no_descriptor/well_known_types.pb.ex
+++ b/test/support/protos/no_descriptor/well_known_types.pb.ex
@@ -1,0 +1,80 @@
+defmodule NoDescriptor.WellKnownTypes.WellKnownRequest do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "well_known_types.WellKnownRequest",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :payload, 1, type: Google.Protobuf.Any
+  field :items, 2, repeated: true, type: Google.Protobuf.Any
+  field :created_at, 3, type: Google.Protobuf.Timestamp, json_name: "createdAt"
+  field :updated_at, 4, type: Google.Protobuf.Timestamp, json_name: "updatedAt"
+  field :timeout, 5, type: Google.Protobuf.Duration
+  field :retry_delay, 6, type: Google.Protobuf.Duration, json_name: "retryDelay"
+  field :metadata, 7, type: Google.Protobuf.Struct
+  field :dynamic_value, 8, type: Google.Protobuf.Value, json_name: "dynamicValue"
+  field :list_value, 9, type: Google.Protobuf.ListValue, json_name: "listValue"
+  field :nullable_string, 10, type: Google.Protobuf.StringValue, json_name: "nullableString"
+  field :nullable_int32, 11, type: Google.Protobuf.Int32Value, json_name: "nullableInt32"
+  field :nullable_int64, 12, type: Google.Protobuf.Int64Value, json_name: "nullableInt64"
+  field :nullable_uint32, 13, type: Google.Protobuf.UInt32Value, json_name: "nullableUint32"
+  field :nullable_uint64, 14, type: Google.Protobuf.UInt64Value, json_name: "nullableUint64"
+  field :nullable_float, 15, type: Google.Protobuf.FloatValue, json_name: "nullableFloat"
+  field :nullable_double, 16, type: Google.Protobuf.DoubleValue, json_name: "nullableDouble"
+  field :nullable_bool, 17, type: Google.Protobuf.BoolValue, json_name: "nullableBool"
+  field :nullable_bytes, 18, type: Google.Protobuf.BytesValue, json_name: "nullableBytes"
+  field :field_mask, 19, type: Google.Protobuf.FieldMask, json_name: "fieldMask"
+end
+
+defmodule NoDescriptor.WellKnownTypes.WellKnownResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "well_known_types.WellKnownResponse",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :processed_at, 1, type: Google.Protobuf.Timestamp, json_name: "processedAt"
+  field :elapsed_time, 2, type: Google.Protobuf.Duration, json_name: "elapsedTime"
+  field :result, 3, type: Google.Protobuf.Struct
+
+  field :string_values, 4,
+    repeated: true,
+    type: Google.Protobuf.StringValue,
+    json_name: "stringValues"
+
+  field :int_values, 5, repeated: true, type: Google.Protobuf.Int32Value, json_name: "intValues"
+end
+
+defmodule NoDescriptor.WellKnownTypes.CustomPayload do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "well_known_types.CustomPayload",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :data, 1, type: :string
+  field :version, 2, type: :int32
+end
+
+defmodule NoDescriptor.WellKnownTypes.WellKnownTypesService.Service do
+  @moduledoc false
+
+  use GRPC.Service,
+    name: "well_known_types.WellKnownTypesService",
+    protoc_gen_elixir_version: "0.16.0"
+
+  rpc :ProcessWellKnownTypes,
+      NoDescriptor.WellKnownTypes.WellKnownRequest,
+      NoDescriptor.WellKnownTypes.WellKnownResponse
+
+  rpc :EmptyMethod, Google.Protobuf.Empty, Google.Protobuf.Empty
+end
+
+defmodule NoDescriptor.WellKnownTypes.WellKnownTypesService.Stub do
+  @moduledoc false
+
+  use GRPC.Stub, service: NoDescriptor.WellKnownTypes.WellKnownTypesService.Service
+end

--- a/test/support/protos/proto2_features.pb.ex
+++ b/test/support/protos/proto2_features.pb.ex
@@ -330,6 +330,37 @@ defmodule Proto2Features.Proto2Request do
           json_name: "anyValues",
           proto3_optional: nil,
           __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "packed_ints",
+          extendee: nil,
+          number: 16,
+          label: :LABEL_REPEATED,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: true,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_index: nil,
+          json_name: "packedInts",
+          proto3_optional: nil,
+          __unknown_fields__: []
         }
       ],
       nested_type: [
@@ -430,6 +461,13 @@ defmodule Proto2Features.Proto2Request do
     map: true
 
   field :any_values, 15, repeated: true, type: Google.Protobuf.Any, json_name: "anyValues"
+
+  field :packed_ints, 16,
+    repeated: true,
+    type: :int32,
+    json_name: "packedInts",
+    packed: true,
+    deprecated: false
 
   extensions [{100, 200}]
 end


### PR DESCRIPTION
This pr adds a `descriptor/0` synthesizer, to start supporting the reflection of grpc services where protos were compiled without descriptor support.  If `descriptor/0` is not present, we automatically try to synthesize and continue.

The compiled elixir code has enough info to service, encode, and decode messages, so it _should_ know enough to tell another service about it through reflection.  This is leveraging that known knowledge (via internal structures)

This has a lot of tests, and test services - regenerating most test services without descriptors for testing.  When `descriptor/0` is preset behavior should be un-changed, so this is opt-in functionality.