### PR TITLE
prep for v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## v0.5.0 (2026-06-22)
 
 ### Enhancements
 
@@ -9,6 +9,7 @@
 ### Internal
 
 - Drop the obsolete `start_supervised({GRPC.Client.Supervisor, []})` calls from the test support — `grpc` 1.0 starts the client supervisor automatically via its application, and the module is no longer a valid child spec. Add `gun` as a test-only dependency since the HTTP client adapters are now optional in `grpc` 1.0.
+- updated to protobuf 0.17.0 and regenerated pb files
 
 ## v0.4.0 (2026-05-05)
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule GrpcReflection.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   @source_url "https://github.com/elixir-grpc/grpc-reflection"
   @description "gRPC reflection server for Elixir"
 
@@ -65,7 +65,7 @@ defmodule GrpcReflection.MixProject do
       # grpc 1.0 made the HTTP client adapters optional; the test suite connects
       # real stubs to the in-process server, so it needs an adapter (Gun).
       {:gun, "~> 2.0", only: :test},
-      {:protobuf, "~> 0.15"}
+      {:protobuf, "~> 0.17"}
     ]
   end
 


### PR DESCRIPTION
Create a new release to make the recent changes available:
- protobuf changes
- grpc and grpc_server 1.0.0 support (thanks @s-lukashenka-micoworks)